### PR TITLE
Multi-Date Spillover Handling & Deduplication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ __pycache__/
 # Temporary processing files (these get archived, but exclude from git)
 *.csv
 last_epos_transform.json
+uploaded_docnumbers.json
+
+# Spill files (temporary, get archived after use)
+uploads/spill/
 
 # Logs
 logs/

--- a/README.md
+++ b/README.md
@@ -47,16 +47,28 @@ The pipeline is designed to be run as a single command and take care of all five
 
 4. **Run the pipeline:**
 
-   **Standard (latest data):**
+   **Standard (yesterday's data):**
 
    ```bash
    python3 run_pipeline.py
+   ```
+
+   **Specific date:**
+
+   ```bash
+   python3 run_pipeline.py --target-date 2025-12-24
    ```
 
    **Custom date range:**
 
    ```bash
    python3 run_pipeline_custom.py --from-date 2025-12-01 --to-date 2025-12-05
+   ```
+
+   **Custom date range with target-date filtering:**
+
+   ```bash
+   python3 run_pipeline_custom.py --from-date 2025-12-24 --to-date 2025-12-26 --target-date 2025-12-25
    ```
 
 That's it! The pipeline will download, transform, upload, archive, and reconcile automatically. If `SLACK_WEBHOOK_URL` is configured, you'll receive notifications for pipeline start, success, failure events, and reconciliation results.
@@ -70,15 +82,21 @@ That's it! The pipeline will download, transform, upload, archive, and reconcile
 ### Core Pipeline Scripts
 
 - `run_pipeline.py`  
-  **Main entry point** — Orchestration script that runs all five phases in order for the latest available data:
+  **Main entry point** — Orchestration script that runs all five phases in order for a target business date:
 
-  1. Download EPOS CSV (`epos_playwright.py`) - downloads "Yesterday's" data
-  2. Transform to single CSV (`epos_to_qb_single.py`)
-  3. Upload to QuickBooks (`qbo_upload.py`)
-  4. Archive files (`run_pipeline.py` - Phase 4)
+  1. Download EPOS CSV (`epos_playwright.py`) - downloads data for target date (defaults to yesterday)
+  2. Transform to single CSV (`epos_to_qb_single.py`) - filters rows by target date and handles spillover
+  3. Upload to QuickBooks (`qbo_upload.py`) - with deduplication to prevent duplicate entries
+  4. Archive files (`run_pipeline.py` - Phase 4) - archives processed files and used spill files
   5. Reconcile EPOS vs QBO totals (`qbo_query.py` - Phase 5)
 
-  Sends Slack notifications for start, success, and failure events. Returns exit code 0 on success, 1 on failure.
+  **Features:**
+  - `--target-date YYYY-MM-DD`: Process a specific business date (defaults to yesterday if not provided)
+  - **Multi-date spillover handling**: Automatically separates rows from other dates into spill files
+  - **Deduplication**: Prevents duplicate uploads using local ledger and QBO API checks
+  - Sends Slack notifications with detailed summary (target date, dates present, row counts, upload stats)
+  
+  Returns exit code 0 on success, 1 on failure.
 
 - `run_pipeline_custom.py`  
   **Custom date range pipeline** — Same as `run_pipeline.py` but allows you to specify a custom date range:
@@ -87,12 +105,21 @@ That's it! The pipeline will download, transform, upload, archive, and reconcile
   python3 run_pipeline_custom.py --from-date 2025-12-01 --to-date 2025-12-05
   ```
 
-  Downloads EPOS data for the specified date range instead of "Yesterday". Also sends Slack notifications with the date range included.  
-  **Archive folders:** Files are archived to `Uploaded/<date_range>/` (e.g., `Uploaded/2025-12-01 to 2025-12-05/`) instead of a single date folder.
+  Downloads EPOS data for the specified date range. Also supports optional `--target-date` filtering:
+  
+  ```bash
+  python3 run_pipeline_custom.py --from-date 2025-12-24 --to-date 2025-12-26 --target-date 2025-12-25
+  ```
+  
+  **Features:**
+  - Downloads data for the specified date range
+  - Optional `--target-date`: Filter to process only a specific date within the range (useful for handling spillover)
+  - Sends Slack notifications with the date range included
+  - **Archive folders:** Files are archived to `Uploaded/<date_range>/` (e.g., `Uploaded/2025-12-01 to 2025-12-05/`) instead of a single date folder
 
 - `epos_playwright.py`  
   Uses **Playwright** to log into EPOS Now, navigate to the BookKeeping report, and download the CSV directly to the repo root directory.  
-  Downloads data for "Yesterday" by default.  
+  Supports `--target-date YYYY-MM-DD` parameter to download data for a specific date (defaults to yesterday if not provided).  
   **Note:** EPOS credentials are loaded from `.env` file or environment variables (see [Initial Setup](#2-configure-credentials-required)).
 
 - `epos_playwright_custom.py`  
@@ -101,14 +128,21 @@ That's it! The pipeline will download, transform, upload, archive, and reconcile
 
 - `epos_to_qb_single.py`  
   Reads the latest raw CSV from the repo root and transforms it into a single consolidated CSV for QuickBooks import.  
-  Output is written to `single_sales_receipts_*.csv` in the repo root.  
-  Creates `last_epos_transform.json` metadata file with file paths and normalized date for archiving.  
+  **Features:**
+  - `--target-date YYYY-MM-DD`: Filters rows to only process the target business date (in WAT timezone)
+  - **Multi-date spillover handling**: Automatically detects and separates rows from other dates into spill files in `uploads/spill/`
+  - **Spill file merging**: When processing a date, automatically checks for and merges existing spill files for that date
+  - Output is written to `single_sales_receipts_*.csv` in the repo root
+  - Creates `last_epos_transform.json` metadata file with file paths, target date, dates present, row counts, and spill file information
+  
   **Dependency:** Uses `sales_recepit_script.py` for transformation logic.
 
 - `qbo_upload.py`  
   Reads the latest `single_sales_receipts_*.csv` from the repo root and uses the **QuickBooks Online REST API** to create Sales Receipts.  
   Each `*SalesReceiptNo` group becomes one Sales Receipt, with the tender type stored in the memo and the **Payment method** automatically mapped from the memo.  
   **Features:**
+  - **Deduplication (Layer A)**: Local ledger (`uploaded_docnumbers.json`) tracks successfully uploaded DocNumbers to prevent re-uploads
+  - **Deduplication (Layer B)**: Bulk QBO API queries check for existing SalesReceipts by DocNumber before uploading
   - Automatically refreshes expired access tokens on 401 errors
   - Maps **Location** data from CSV to QuickBooks **Departments** (shown as "Location" in QBO UI)
   - Auto-creates missing Items if `AUTO_CREATE_ITEMS = True`
@@ -117,6 +151,7 @@ That's it! The pipeline will download, transform, upload, archive, and reconcile
     - QBO *backs out* VAT for display using `GlobalTaxCalculation = "TaxInclusive"` and `TaxInclusiveAmt`
   - Validates API responses and raises errors on upload failures
   - Uses efficient `TokenManager` to avoid redundant token checks
+  - Tracks upload statistics (attempted/skipped/uploaded/failed) in metadata
 
 ### Supporting Files
 
@@ -145,9 +180,13 @@ That's it! The pipeline will download, transform, upload, archive, and reconcile
 ### Data Folders
 
 - `Uploaded/<date>/` or `Uploaded/<date_range>/` – Archived files after successful upload (created automatically by Phase 4)
-  - Contains raw CSV, processed CSV(s), and `last_epos_transform.json` metadata
-  - Standard pipeline: Organized by normalized date (format: `YYYY-MM-DD`)
+  - Contains raw CSV, processed CSV(s), used spill files, and `last_epos_transform.json` metadata
+  - Standard pipeline: Organized by target date (format: `YYYY-MM-DD`)
   - Custom pipeline: Organized by date range (format: `YYYY-MM-DD to YYYY-MM-DD`)
+- `uploads/spill/` – Spillover files for future dates (created automatically, cleaned up after use)
+  - Contains `BookKeeping_spill_YYYY-MM-DD.csv` files for dates that appear in CSV downloads for other dates
+  - These files are automatically merged when processing their target date
+  - Moved to `Uploaded/<date>/` after successful upload
 - `logs/` – Log files for each full pipeline run (created automatically by `run_pipeline.py`)
 
 **Note:** Files are temporarily stored in the repo root during processing, then automatically archived after successful upload.
@@ -480,21 +519,53 @@ code-scripts/
    - Metadata file (`last_epos_transform.json`)
 5. **Reconciliation Phase:** EPOS totals are compared against QBO totals for the processed date(s) to verify data integrity. Results are logged and sent via Slack notification.
 
-The normalized date used for archiving is extracted from the CSV's `*SalesReceiptDate` column, ensuring files are organized by the actual transaction date rather than processing date.
+The target date used for archiving is either:
+- The `--target-date` parameter provided (preferred)
+- The normalized date extracted from the CSV's `*SalesReceiptDate` column (fallback)
+
+This ensures files are organized by the intended business date rather than processing date.
+
+**Multi-Date Spillover Handling:**
+When processing a target date, the pipeline:
+1. Filters rows by target date (using WAT timezone conversion)
+2. Separates spillover rows (from other dates) into `uploads/spill/BookKeeping_spill_YYYY-MM-DD.csv` files
+3. Checks for existing spill files matching the target date and merges them
+4. Processes all merged data together
+5. Archives used spill files to `Uploaded/<date>/` after successful upload
+6. Keeps future-date spill files in `uploads/spill/` for later processing
+
+This prevents duplicate uploads when spillover rows from one day's CSV are processed again on their actual date.
 
 ---
 
 ## Running the Full Pipeline
 
-### Standard Pipeline (Latest Data)
+### Standard Pipeline (Target Date)
 
 From the `code-scripts` directory, run:
 
 ```bash
+# Process yesterday's data (default)
 python3 run_pipeline.py
+
+# Process a specific date
+python3 run_pipeline.py --target-date 2025-12-24
 ```
 
-This downloads "Yesterday's" data from EPOS and processes it.
+**What happens:**
+1. Downloads CSV for the target date (or yesterday if not specified)
+2. Filters rows to only process the target date (handles timezone differences)
+3. Separates spillover rows (from other dates) into `uploads/spill/` files
+4. Checks for and merges existing spill files for the target date
+5. Uploads to QuickBooks with deduplication
+6. Archives all files including used spill files
+
+**Multi-Date Spillover Handling:**
+Due to timezone differences, EPOS CSV downloads for one date may include rows from adjacent dates. The pipeline automatically:
+- Filters rows by target date using WAT timezone conversion
+- Saves spillover rows (other dates) to `uploads/spill/BookKeeping_spill_YYYY-MM-DD.csv`
+- When processing a date, automatically checks for and merges existing spill files for that date
+- Archives spill files after successful upload
 
 ### Windows Task Scheduler
 
@@ -539,16 +610,24 @@ python3 run_pipeline_custom.py --from-date 2025-12-01 --to-date 2025-12-05
 
 - `--from-date`: Start date in `YYYY-MM-DD` format (required)
 - `--to-date`: End date in `YYYY-MM-DD` format (required)
+- `--target-date`: Optional target business date in `YYYY-MM-DD` format. If provided, filters rows to only this date (useful for handling spillover within a range)
 
-**Example:**
+**Examples:**
 
 ```bash
 # Single day
 python3 run_pipeline_custom.py --from-date 2025-12-13 --to-date 2025-12-13
 
-# Date range
+# Date range (processes all dates in range)
 python3 run_pipeline_custom.py --from-date 2025-12-01 --to-date 2025-12-05
+
+# Date range with target-date filtering (downloads range but processes only one date)
+python3 run_pipeline_custom.py --from-date 2025-12-24 --to-date 2025-12-26 --target-date 2025-12-25
 ```
+
+**When to use `--target-date` with date ranges:**
+- When you want to download a date range but process only a specific date (e.g., to handle spillover from previous runs)
+- When testing spillover handling for a specific date
 
 ### Pipeline Phases
 
@@ -787,10 +866,30 @@ python3 qbo_query.py list 2025-10-15 2025-10-17 --max-results 20
 
 - **Symptom:** Running pipeline multiple times creates duplicate entries
 - **Solutions:**
-  - QuickBooks doesn't prevent duplicates by default
-  - Check `DocNumber` in created receipts — they should be unique
-  - Consider adding duplicate detection logic or only running once per day
+  - The pipeline now includes **automatic deduplication**:
+    - **Layer A**: Local ledger (`uploaded_docnumbers.json`) tracks successfully uploaded DocNumbers
+    - **Layer B**: Bulk QBO API queries check for existing SalesReceipts before uploading
+  - Duplicate DocNumbers are automatically skipped with a log message
+  - If you need to re-upload, delete existing receipts first using `qbo_query.py delete`
   - For testing, use QuickBooks Sandbox to avoid production data issues
+
+### Spillover Files Not Being Created
+
+- **Symptom:** No spill files appear in `uploads/spill/` folder
+- **Solutions:**
+  - Verify that the CSV actually contains rows from multiple dates (check date distribution in logs)
+  - Ensure `--target-date` is provided when running the pipeline
+  - Check that spillover rows exist (rows with dates different from target date)
+  - Spill files are only created when there are rows from dates other than the target date
+
+### Spill Files Not Being Merged
+
+- **Symptom:** Spill files exist but aren't being merged when processing target date
+- **Solutions:**
+  - Verify spill file naming: `BookKeeping_spill_YYYY-MM-DD.csv` (must match target date exactly)
+  - Check that `--target-date` matches the date in the spill filename
+  - Ensure spill files are in `uploads/spill/` directory (relative to repo root)
+  - Check logs for "Found existing spill file" messages
 
 ---
 

--- a/epos_playwright.py
+++ b/epos_playwright.py
@@ -1,4 +1,6 @@
 import re
+import sys
+from datetime import datetime
 from playwright.sync_api import Playwright, sync_playwright, expect
 import os
 
@@ -7,7 +9,105 @@ from load_env import load_env_file
 load_env_file()
 
 
-def run(playwright: Playwright) -> None:
+def navigate_to_month(page, target_date: str) -> None:
+    """Navigate calendar to the correct month if needed."""
+    target_dt = datetime.strptime(target_date, "%Y-%m-%d")
+    target_month_year = target_dt.strftime("%B %Y")
+    target_dt_month = datetime.strptime(target_month_year, "%B %Y")
+    
+    page.wait_for_timeout(500)
+    calendar_title = page.locator('.ajax__calendar_title:visible, td.title:visible, th.title:visible').first
+    
+    if calendar_title.count() == 0:
+        return
+    
+    try:
+        current_text = calendar_title.inner_text().strip().replace(",", "").strip()
+        if target_month_year in current_text:
+            return
+        
+        current_dt = datetime.strptime(current_text, "%B %Y")
+        prev_btn = page.locator('.ajax__calendar_prev:visible, a.ajax__calendar_prev:visible, a[title*="Previous" i]:visible, a[title*="Prev" i]:visible').first
+        next_btn = page.locator('.ajax__calendar_next:visible, a.ajax__calendar_next:visible, a[title*="Next" i]:visible').first
+        
+        for _ in range(24):  # Max 2 years
+            current_text = calendar_title.inner_text().strip().replace(",", "").strip()
+            if target_month_year in current_text:
+                break
+            
+            try:
+                current_dt = datetime.strptime(current_text, "%B %Y")
+            except ValueError:
+                break
+            
+            btn = prev_btn if current_dt > target_dt_month else next_btn
+            if btn.count() > 0:
+                btn.click()
+                page.wait_for_timeout(400)
+                prev_btn = page.locator('.ajax__calendar_prev:visible, a.ajax__calendar_prev:visible, a[title*="Previous" i]:visible, a[title*="Prev" i]:visible').first
+                next_btn = page.locator('.ajax__calendar_next:visible, a.ajax__calendar_next:visible, a[title*="Next" i]:visible').first
+            else:
+                break
+    except Exception:
+        pass
+
+
+def click_date_simple(page, target_date: str) -> None:
+    """Click a date in the calendar - navigate to correct month first, then find by title."""
+    target_dt = datetime.strptime(target_date, "%Y-%m-%d")
+    day_number = str(target_dt.day)
+    target_titles = [
+        target_dt.strftime("%d %B %Y"),      # "10 November 2025"
+        target_dt.strftime("%d %B, %Y"),     # "10 November, 2025"
+    ]
+    
+    navigate_to_month(page, target_date)
+    page.wait_for_timeout(500)
+    
+    # Try to find by title attribute (most reliable)
+    for title in target_titles:
+        day = page.locator(f'[id*="day"][title="{title}"]:visible').first
+        if day.count() > 0:
+            day.click()
+            page.wait_for_timeout(200)
+            return
+    
+    # Fallback: find by day number and verify title matches
+    for day_elem in page.locator(f'[id*="day"]:visible').all():
+        try:
+            if day_elem.inner_text().strip() == day_number:
+                day_title = day_elem.get_attribute("title") or ""
+                if any(title in day_title for title in target_titles):
+                    day_elem.click()
+                    page.wait_for_timeout(200)
+                    return
+        except:
+            continue
+    
+    raise RuntimeError(f"Could not find calendar day for date {target_date}")
+
+
+def get_target_date_from_args() -> str:
+    """Get target_date from command line args or environment variable. Defaults to yesterday."""
+    from datetime import timedelta
+    
+    # Check command line args
+    if "--target-date" in sys.argv:
+        idx = sys.argv.index("--target-date")
+        if idx + 1 < len(sys.argv):
+            return sys.argv[idx + 1]
+    
+    # Check environment variable
+    target_date = os.environ.get("TARGET_DATE")
+    if target_date:
+        return target_date
+    
+    # Default to yesterday
+    yesterday = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    return yesterday
+
+
+def run(playwright: Playwright, target_date: str = None) -> None:
     # Get credentials from environment variables
     epos_username = os.environ.get("EPOS_USERNAME")
     epos_password = os.environ.get("EPOS_PASSWORD")
@@ -25,6 +125,11 @@ def run(playwright: Playwright) -> None:
             "  export EPOS_PASSWORD='your_password'"
         )
     
+    # Use provided target_date or default to yesterday
+    if not target_date:
+        from datetime import timedelta
+        target_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
+    
     browser = playwright.chromium.launch(headless=True)
     context = browser.new_context()
     page = context.new_page()
@@ -34,7 +139,25 @@ def run(playwright: Playwright) -> None:
     page.get_by_role("textbox", name="Password").click()
     page.get_by_role("textbox", name="Password").fill(epos_password)
     page.get_by_role("button", name="Log in").click()
-    page.get_by_label("Show data from").select_option("Yesterday")
+    
+    # Select Custom date range for the target date
+    page.get_by_label("Show data from").select_option("Custom")
+    
+    # FROM date
+    page.locator("#MainContent_timeControl_btnFromDate").click()
+    page.wait_for_timeout(500)
+    click_date_simple(page, target_date)
+    
+    # TO date (same as FROM for single day)
+    page.locator("#MainContent_timeControl_btnToDate").click()
+    page.wait_for_timeout(500)
+    click_date_simple(page, target_date)
+    
+    # Apply date range
+    page.locator("#MainContent_timeControl_btnApplyDate").click()
+    page.wait_for_timeout(500)
+    
+    # Download CSV
     with page.expect_download() as download_info:
         page.get_by_role("button", name="Export to .csv").click()
     download = download_info.value
@@ -52,5 +175,7 @@ def run(playwright: Playwright) -> None:
     browser.close()
 
 
-with sync_playwright() as playwright:
-    run(playwright)
+if __name__ == "__main__":
+    target_date = get_target_date_from_args()
+    with sync_playwright() as playwright:
+        run(playwright, target_date)

--- a/epos_to_qb_single.py
+++ b/epos_to_qb_single.py
@@ -1,10 +1,12 @@
 import os
 import glob
 import json
-from datetime import datetime
+import sys
+from datetime import datetime, timezone, timedelta
+from typing import Optional, Tuple, List
 import pandas as pd
 
-from sales_recepit_script import TransformOptions, transform_dataframe
+from sales_recepit_script import TransformOptions, transform_dataframe, parse_date
 
 
 def get_repo_root() -> str:
@@ -25,6 +27,149 @@ def find_latest_raw_file(repo_root: str) -> str:
     return max(files, key=os.path.getmtime)
 
 
+# WAT timezone (UTC+1)
+WAT_TZ = timezone(timedelta(hours=1))
+
+
+def get_target_date_from_args() -> Optional[str]:
+    """Get target_date from command line args or environment variable."""
+    # Check command line args
+    if "--target-date" in sys.argv:
+        idx = sys.argv.index("--target-date")
+        if idx + 1 < len(sys.argv):
+            return sys.argv[idx + 1]
+    
+    # Check environment variable
+    target_date = os.environ.get("TARGET_DATE")
+    if target_date:
+        return target_date
+    
+    return None
+
+
+def filter_rows_by_target_date(
+    df: pd.DataFrame,
+    target_date: str,
+    raw_file: str
+) -> Tuple[pd.DataFrame, pd.DataFrame, dict]:
+    """
+    Filter rows by target date and separate spillover rows.
+    
+    Returns:
+        (target_rows, spillover_rows, stats_dict)
+    """
+    target_dt = datetime.strptime(target_date, "%Y-%m-%d")
+    target_date_str = target_dt.strftime("%Y-%m-%d")
+    target_prefix = f"SR-{target_dt.strftime('%Y%m%d')}-"
+    
+    # Parse dates from Date/Time column
+    dates_series = df["Date/Time"].apply(parse_date) if "Date/Time" in df.columns else pd.Series([None] * len(df))
+    
+    # Convert to WAT timezone and extract date portion
+    def get_date_in_wat(dt) -> Optional[str]:
+        # Handle None, NaT, or other missing values - check before any operations
+        try:
+            if dt is None or pd.isna(dt):
+                return None
+        except (TypeError, ValueError):
+            return None
+        
+        # Handle pandas Timestamp objects and datetime objects
+        try:
+            # If datetime is naive, assume it's already in WAT
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=WAT_TZ)
+            # Convert to WAT if needed
+            elif dt.tzinfo != WAT_TZ:
+                dt = dt.astimezone(WAT_TZ)
+            return dt.date().strftime("%Y-%m-%d")
+        except (AttributeError, ValueError, TypeError):
+            return None
+    
+    date_strings = dates_series.apply(get_date_in_wat)
+    
+    # Filter: keep rows where date matches target_date
+    target_mask = date_strings == target_date_str
+    target_rows = df[target_mask].copy().reset_index(drop=True)
+    spillover_rows = df[~target_mask].copy().reset_index(drop=True)
+    
+    # Collect statistics - filter out None/NaN before computing min/max
+    date_strings_clean = date_strings.dropna()
+    dates_present_list = sorted(date_strings_clean.unique().tolist()) if len(date_strings_clean) > 0 else []
+    
+    # Debug: show date distribution
+    date_counts = date_strings.value_counts()
+    print(f"\nDate distribution in CSV:")
+    for date_val, count in date_counts.items():
+        marker = " <-- TARGET" if date_val == target_date_str else ""
+        print(f"  {date_val}: {count} rows{marker}")
+    
+    stats = {
+        "rows_total": len(df),
+        "rows_kept": len(target_rows),
+        "rows_spilled": len(spillover_rows),
+        "dates_present": dates_present_list,
+        "min_dt": dates_present_list[0] if dates_present_list else None,
+        "max_dt": dates_present_list[-1] if dates_present_list else None,
+    }
+    
+    print(f"\nFiltering by target date: {target_date}")
+    print(f"  Total rows: {stats['rows_total']}")
+    print(f"  Rows kept (target date): {stats['rows_kept']}")
+    print(f"  Rows spilled (other dates): {stats['rows_spilled']}")
+    print(f"  Dates present in CSV: {', '.join(stats['dates_present'])}")
+    
+    if len(spillover_rows) > 0:
+        spillover_dates = date_strings[~target_mask].value_counts()
+        print(f"\nSpillover date breakdown:")
+        for date_val, count in spillover_dates.items():
+            print(f"  {date_val}: {count} rows")
+    
+    return target_rows, spillover_rows, stats
+
+
+def write_spillover_files(
+    spillover_transformed: pd.DataFrame,
+    repo_root: str,
+    raw_file: str,
+    stats: dict
+) -> List[str]:
+    """
+    Write transformed spillover rows to separate CSV files grouped by date.
+    Returns list of spill file paths (relative to repo_root).
+    """
+    if len(spillover_transformed) == 0:
+        return []
+    
+    # Group by *SalesReceiptDate (which is the date string in YYYY-MM-DD format)
+    if "*SalesReceiptDate" not in spillover_transformed.columns:
+        print("[WARN] Cannot group spillover by date: *SalesReceiptDate column missing")
+        return []
+    
+    # Create uploads/spill directory
+    spill_dir = os.path.join(repo_root, "uploads", "spill")
+    os.makedirs(spill_dir, exist_ok=True)
+    
+    spill_files = []
+    
+    # Group by date and write separate files
+    for spill_date, group in spillover_transformed.groupby("*SalesReceiptDate", dropna=False):
+        if pd.isna(spill_date):
+            spill_date_str = "unknown"
+        else:
+            spill_date_str = str(spill_date)
+        
+        spill_filename = f"BookKeeping_spill_{spill_date_str}.csv"
+        spill_path = os.path.join(spill_dir, spill_filename)
+        
+        group.to_csv(spill_path, index=False)
+        # Store relative path from repo_root
+        spill_files.append(f"uploads/spill/{spill_filename}")
+        print(f"  Wrote spillover file: {spill_filename} ({len(group)} rows for date {spill_date_str})")
+    
+    return spill_files
+
+
 def extract_date_from_dataframe(df: pd.DataFrame) -> str:
     """Extract and normalize the date from the transformed dataframe."""
     # Get the first non-null date from *SalesReceiptDate column
@@ -42,17 +187,87 @@ def extract_date_from_dataframe(df: pd.DataFrame) -> str:
     return datetime.now().strftime("%Y-%m-%d")
 
 
+def find_spill_files_for_date(repo_root: str, target_date: str) -> List[str]:
+    """Find existing spill files for the target date."""
+    spill_dir = os.path.join(repo_root, "uploads", "spill")
+    if not os.path.exists(spill_dir):
+        return []
+    
+    spill_files = []
+    spill_filename_pattern = f"BookKeeping_spill_{target_date}.csv"
+    spill_path = os.path.join(spill_dir, spill_filename_pattern)
+    
+    if os.path.exists(spill_path):
+        spill_files.append(spill_path)
+        print(f"Found existing spill file for {target_date}: {spill_filename_pattern}")
+    
+    return spill_files
+
+
 def main():
     repo_root = get_repo_root()
 
-    # 1) Pick latest raw BookKeeping CSV from repo root
+    # 1) Get target_date from args or env
+    target_date = get_target_date_from_args()
+    if not target_date:
+        print("Warning: No --target-date provided. Processing all rows without filtering.")
+        print("  Usage: python epos_to_qb_single.py --target-date YYYY-MM-DD")
+        print("  Or set TARGET_DATE environment variable")
+
+    # 2) Pick latest raw BookKeeping CSV from repo root
     raw_file = find_latest_raw_file(repo_root)
     print(f"Using raw file: {raw_file}")
 
-    # 2) Load raw CSV
+    # 3) Load raw CSV
     df = pd.read_csv(raw_file)
 
-    # 3) Transform using the existing logic (but no splitting)
+    # 4) Filter by target_date if provided
+    spillover_rows = pd.DataFrame()
+    stats = {
+        "rows_total": len(df),
+        "rows_kept": len(df),
+        "rows_spilled": 0,
+        "dates_present": [],
+        "min_dt": None,
+        "max_dt": None,
+    }
+    
+    if target_date:
+        target_df, spillover_rows, stats = filter_rows_by_target_date(df, target_date, raw_file)
+        df = target_df  # Use filtered dataframe for transformation
+        
+        if len(df) == 0:
+            raise ValueError(f"No rows found for target date {target_date}. Cannot proceed with empty dataset.")
+    else:
+        # If no target_date, analyze dates present
+        dates_series = df["Date/Time"].apply(parse_date) if "Date/Time" in df.columns else pd.Series([None] * len(df))
+        def get_date_in_wat(dt) -> Optional[str]:
+            # Handle None, NaT, or other missing values - check before any operations
+            try:
+                if dt is None or pd.isna(dt):
+                    return None
+            except (TypeError, ValueError):
+                return None
+            
+            # Handle pandas Timestamp objects and datetime objects
+            try:
+                # If datetime is naive, assume it's already in WAT
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=WAT_TZ)
+                # Convert to WAT if needed
+                elif dt.tzinfo != WAT_TZ:
+                    dt = dt.astimezone(WAT_TZ)
+                return dt.date().strftime("%Y-%m-%d")
+            except (AttributeError, ValueError, TypeError):
+                return None
+        date_strings = dates_series.apply(get_date_in_wat)
+        date_strings_clean = date_strings.dropna()
+        dates_present_list = sorted(date_strings_clean.unique().tolist()) if len(date_strings_clean) > 0 else []
+        stats["dates_present"] = dates_present_list
+        stats["min_dt"] = dates_present_list[0] if dates_present_list else None
+        stats["max_dt"] = dates_present_list[-1] if dates_present_list else None
+
+    # 5) Transform using the existing logic (but no splitting)
     opts = TransformOptions(
         deposit_account="100900 - Undeposited Funds",
         date_format="%Y-%m-%d",
@@ -65,24 +280,65 @@ def main():
 
     transformed = transform_dataframe(df, opts)
 
-    # 4) Extract normalized date for archiving
-    normalized_date = extract_date_from_dataframe(transformed)
+    # 6) Check for existing spill files for target_date and merge them (after transformation)
+    used_spill_files = []  # Track which spill files were used
+    if target_date:
+        existing_spill_files = find_spill_files_for_date(repo_root, target_date)
+        if existing_spill_files:
+            print(f"\nFound {len(existing_spill_files)} existing spill file(s) for target date {target_date}, merging...")
+            for spill_file in existing_spill_files:
+                try:
+                    spill_df = pd.read_csv(spill_file)
+                    print(f"  Merging {len(spill_df)} rows from {os.path.basename(spill_file)}")
+                    # Concatenate spill data (already transformed) with transformed data
+                    transformed = pd.concat([transformed, spill_df], ignore_index=True)
+                    # Track this spill file as used (store relative path)
+                    spill_rel_path = os.path.relpath(spill_file, repo_root)
+                    used_spill_files.append(spill_rel_path)
+                except Exception as e:
+                    print(f"  Warning: Failed to load spill file {spill_file}: {e}")
 
-    # 5) Write ONE QuickBooks-ready CSV in repo root
+    # 7) Process spillover rows if any
+    spill_files = []
+    if len(spillover_rows) > 0:
+        print("\nProcessing spillover rows...")
+        # Transform spillover rows first, then write them
+        spillover_transformed = transform_dataframe(spillover_rows, opts)
+        spill_files = write_spillover_files(spillover_transformed, repo_root, raw_file, stats)
+        print(f"Created {len(spill_files)} spill file(s)")
+    else:
+        print("No spillover rows detected.")
+
+    # 7) Extract normalized date for archiving (use target_date if provided, otherwise first row date)
+    if target_date:
+        normalized_date = target_date
+    else:
+        normalized_date = extract_date_from_dataframe(transformed)
+
+    # 8) Write ONE QuickBooks-ready CSV in repo root
     base_name = os.path.splitext(os.path.basename(raw_file))[0]
     output_filename = f"single_sales_receipts_{base_name}.csv"
     output_path = os.path.join(repo_root, output_filename)
 
     transformed.to_csv(output_path, index=False)
-    print(f"Wrote combined QuickBooks file: {output_path}")
+    print(f"\nWrote combined QuickBooks file: {output_path}")
     print(f"Rows (including header): {len(transformed) + 1}")
 
-    # 6) Write metadata file for archiving
+    # 9) Write metadata file for archiving
     metadata = {
         "raw_file": os.path.basename(raw_file),
         "raw_file_path": raw_file,
         "processed_files": [output_filename],
         "normalized_date": normalized_date,
+        "target_date": target_date,
+        "dates_present": stats["dates_present"],
+        "rows_total": stats["rows_total"],
+        "rows_kept": stats["rows_kept"],
+        "rows_spilled": stats["rows_spilled"],
+        "spill_files": spill_files,  # New spill files created
+        "used_spill_files": used_spill_files,  # Spill files that were merged/used
+        "min_dt": stats["min_dt"],
+        "max_dt": stats["max_dt"],
         "processed_at": datetime.now().isoformat(),
     }
     


### PR DESCRIPTION
### Problem

EPOS CSV downloads for a specific date sometimes include rows from adjacent dates due to timezone differences, causing duplicate upload errors when processing the next day.

### Solution

- **Target Date Filtering**: Added `-target-date` parameter to filter rows by business date (WAT timezone)
- **Spillover Handling**: Automatically separates rows from other dates into spill files (`uploads/spill/`)
- **Spill File Merging**: When processing a date, automatically checks for and merges existing spill files
- **Deduplication**: Two-layer deduplication prevents duplicate uploads:
    - Layer A: Local ledger (`uploaded_docnumbers.json`)
    - Layer B: QBO API bulk check for existing DocNumbers
- **Enhanced Notifications**: Slack notifications now include detailed summary (target date, dates present, row counts, upload stats)

### Changes

- `run_pipeline.py`: Added `-target-date` support (defaults to yesterday)
- `epos_playwright.py`: Support downloading specific dates instead of always "Yesterday"
- `epos_to_qb_single.py`: Target date filtering, spillover splitting, spill file merging
- `qbo_upload.py`: Deduplication layers, upload statistics tracking
- `run_pipeline_custom.py`: Optional `-target-date` filtering for date ranges
- `slack_notify.py`: Enhanced notifications with summary information
- `README.md`: Updated documentation with new features and usage examples

### Testing

- ✅ Tested with Dec 24th CSV containing Dec 25th spillover rows
- ✅ Verified spill files are created and merged correctly
- ✅ Confirmed deduplication prevents duplicate uploads
- ✅ Validated archive logic handles spill files properly