### PR TITLE
QBO webhooks: receiver, Slack notifications, and Cloudflare Tunnel ingress

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -18,6 +18,8 @@ OIAT_RUNTIME_ENV=sandbox
 # Get these from developer.intuit.com under your "Development" keys.
 QBO_CLIENT_ID=replace_with_intuit_development_client_id
 QBO_CLIENT_SECRET=replace_with_intuit_development_client_secret
+# Intuit Webhooks verifier token for sandbox/development webhook tests.
+QBO_WEBHOOK_VERIFIER_TOKEN=replace_with_intuit_development_webhook_verifier_token
 
 # Local Django settings
 DJANGO_DEBUG=1
@@ -54,8 +56,14 @@ EPOS_USERNAME_A=replace_with_sandbox_epos_username
 EPOS_PASSWORD_A=replace_with_sandbox_epos_password
 
 # Optional Slack webhooks
+# These names are referenced by company JSON slack.webhook_url_env_key.
 SLACK_WEBHOOK_URL_A=
 SLACK_WEBHOOK_URL_B=
+
+# Optional QuickBooks webhook Slack destinations, separate from pipeline Slack.
+QBO_WEBHOOK_SLACK_URL_COMPANY_A=
+QBO_WEBHOOK_SLACK_URL_COMPANY_B=
+QBO_WEBHOOK_SLACK_URL=
 
 # Scheduler worker
 OIAT_SCHEDULER_POLL_SECONDS=15

--- a/.env.development.example
+++ b/.env.development.example
@@ -63,6 +63,7 @@ SLACK_WEBHOOK_URL_B=
 # Optional QuickBooks webhook Slack destinations, separate from pipeline Slack.
 QBO_WEBHOOK_SLACK_URL_COMPANY_A=
 QBO_WEBHOOK_SLACK_URL_COMPANY_B=
+QBO_WEBHOOK_SLACK_URL_TEST=
 QBO_WEBHOOK_SLACK_URL=
 
 # Scheduler worker

--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,8 @@ OIAT_RUNTIME_ENV=production
 # Local sandbox/staging should use your Intuit Development app.
 QBO_CLIENT_ID=your_client_id_here
 QBO_CLIENT_SECRET=your_client_secret_here
+# Intuit Webhooks "verifier token" for validating intuit-signature headers.
+QBO_WEBHOOK_VERIFIER_TOKEN=your_intuit_webhook_verifier_token
 
 # Django deployment settings
 # Required when running with Docker / gunicorn
@@ -44,10 +46,18 @@ EPOS_USERNAME_B=your_company_b_epos_username
 EPOS_PASSWORD_B=your_company_b_epos_password
 
 # Company A (AKPONORA VENTURES LTD.) Slack Webhook (optional)
+# Referenced by code_scripts/companies/company_a.json as SLACK_WEBHOOK_URL_A.
 SLACK_WEBHOOK_URL_A=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 
 # Company B (GOLDPLATES FEASTHOUSE LTD.) Slack Webhook (optional)
+# Referenced by code_scripts/companies/company_b.json as SLACK_WEBHOOK_URL_B.
 SLACK_WEBHOOK_URL_B=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+
+# QuickBooks webhook Slack destinations (separate from pipeline Slack webhooks).
+# The company-specific value wins; QBO_WEBHOOK_SLACK_URL is an optional fallback.
+QBO_WEBHOOK_SLACK_URL_COMPANY_A=https://hooks.slack.com/services/YOUR/QBO/WEBHOOK
+QBO_WEBHOOK_SLACK_URL_COMPANY_B=
+QBO_WEBHOOK_SLACK_URL=
 
 # Note: QBO_REALM_ID is no longer needed here - it's now in companies/company_a.json and companies/company_b.json
 # Note: The .env.gp file is no longer needed - all credentials are now in this single .env file

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,15 @@ TAILSCALE_BIND_IP=100.125.133.118
 # - Zone.DNS:Edit
 CF_API_TOKEN=your_cloudflare_dns_api_token
 
+# Cloudflare Tunnel token for the cloudflared service (public inbound-webhook ingress).
+# The portal stays tailnet-only; this tunnel exposes ONLY the QBO webhook path on a
+# dedicated public hostname (e.g. qbo-webhooks.oiatsolutions.com) so Intuit can reach it.
+# Create the tunnel in Cloudflare Zero Trust > Networks > Tunnels, add a Public Hostname
+# routed to http://web:8000 with Path = epos-qbo/webhooks/quickbooks , then paste its token here.
+# Remember to add the webhook hostname (e.g. qbo-webhooks.oiatsolutions.com) to
+# DJANGO_ALLOWED_HOSTS above, since cloudflared forwards that Host header to Django.
+CLOUDFLARE_TUNNEL_TOKEN=your_cloudflare_tunnel_token
+
 # This section is for getting token info from the windows computer (optional)
 # Only needed if you're using a token broker setup
 QBO_TOKEN_BROKER_URL=http://127.0.0.1:8765/token

--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,7 @@ SLACK_WEBHOOK_URL_B=https://hooks.slack.com/services/YOUR/WEBHOOK/URL
 # The company-specific value wins; QBO_WEBHOOK_SLACK_URL is an optional fallback.
 QBO_WEBHOOK_SLACK_URL_COMPANY_A=https://hooks.slack.com/services/YOUR/QBO/WEBHOOK
 QBO_WEBHOOK_SLACK_URL_COMPANY_B=
+QBO_WEBHOOK_SLACK_URL_TEST=
 QBO_WEBHOOK_SLACK_URL=
 
 # Note: QBO_REALM_ID is no longer needed here - it's now in companies/company_a.json and companies/company_b.json

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Retention/lifecycle plan: [`docs/ARTIFACT_RETENTION_PLAN.md`](docs/ARTIFACT_RETE
 - QBO: `QBO_CLIENT_ID`, `QBO_CLIENT_SECRET`
 - EPOS: credentials are referenced per-company via `epos.username_env_key` / `epos.password_env_key`
 - Portal: `DJANGO_SECRET_KEY`, `DJANGO_ALLOWED_HOSTS`, `DJANGO_CSRF_TRUSTED_ORIGINS` (when behind TLS proxy)
-- QuickBooks webhooks: `QBO_WEBHOOK_VERIFIER_TOKEN`; register `https://<portal-domain>/epos-qbo/webhooks/quickbooks/` in Intuit; Slack destinations use `QBO_WEBHOOK_SLACK_URL_COMPANY_A/B`
+- QuickBooks webhooks: `QBO_WEBHOOK_VERIFIER_TOKEN`; register `https://<portal-domain>/epos-qbo/webhooks/quickbooks/` in Intuit; Slack destinations use `QBO_WEBHOOK_SLACK_URL_COMPANY_A/B` (`QBO_WEBHOOK_SLACK_URL_TEST` can override Intuit sample events)
 - Slack: webhook URL env keys are referenced per-company, e.g. `SLACK_WEBHOOK_URL_A`
 - Portal base URL/domain is used for run links in operator output (Docker uses `PORTAL_DOMAIN`)
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Retention/lifecycle plan: [`docs/ARTIFACT_RETENTION_PLAN.md`](docs/ARTIFACT_RETE
 - QBO: `QBO_CLIENT_ID`, `QBO_CLIENT_SECRET`
 - EPOS: credentials are referenced per-company via `epos.username_env_key` / `epos.password_env_key`
 - Portal: `DJANGO_SECRET_KEY`, `DJANGO_ALLOWED_HOSTS`, `DJANGO_CSRF_TRUSTED_ORIGINS` (when behind TLS proxy)
-- QuickBooks webhooks: `QBO_WEBHOOK_VERIFIER_TOKEN`; register `https://<portal-domain>/epos-qbo/webhooks/quickbooks/` in Intuit; Slack destinations use `QBO_WEBHOOK_SLACK_URL_COMPANY_A/B` (`QBO_WEBHOOK_SLACK_URL_TEST` can override Intuit sample events)
+- QuickBooks webhooks: `QBO_WEBHOOK_VERIFIER_TOKEN`; public ingress via Cloudflare Tunnel (`CLOUDFLARE_TUNNEL_TOKEN`, see [Webhook ingress](#webhook-ingress-cloudflare-tunnel)); register `https://qbo-webhooks.<your-domain>/epos-qbo/webhooks/quickbooks/` in Intuit; Slack destinations use `QBO_WEBHOOK_SLACK_URL_COMPANY_A/B` (`QBO_WEBHOOK_SLACK_URL_TEST` can override Intuit sample events)
 - Slack: webhook URL env keys are referenced per-company, e.g. `SLACK_WEBHOOK_URL_A`
 - Portal base URL/domain is used for run links in operator output (Docker uses `PORTAL_DOMAIN`)
 
@@ -240,19 +240,46 @@ Docker Compose services (see `docker-compose.yml`):
 - `caddy`: HTTPS reverse proxy (Cloudflare DNS challenge) bound to the host Tailscale IP
 - `web`: Django + Gunicorn (runs migrations on start)
 - `scheduler`: runs `python manage.py run_schedule_worker` (DB schedules → `RunJob`)
+- `cloudflared`: Cloudflare Tunnel exposing only the public webhook endpoint (see [Webhook ingress](#webhook-ingress-cloudflare-tunnel))
 
 Networking model:
 
 - Tailscale network gates access to the host
-- Cloudflare DNS record is **DNS-only** (no Cloudflare proxy/WAF)
+- The portal's Cloudflare DNS record is **DNS-only** (no Cloudflare proxy/WAF)
+- The webhook hostname is the exception: it is Cloudflare-proxied and served via the `cloudflared` tunnel, so inbound webhooks from the public internet can reach an otherwise tailnet-only host
 
 Update flow:
 
 ```bash
 git pull
 docker compose build
-docker compose up -d caddy web scheduler
+docker compose up -d caddy web scheduler cloudflared
 ```
+
+### Webhook ingress (Cloudflare Tunnel)
+
+The portal is reachable **only over Tailscale** (Caddy binds to the host's Tailscale IP in the `100.64.0.0/10` CGNAT range). That keeps the dashboard private — but QuickBooks Online webhooks are sent from Intuit's public servers, which cannot reach a Tailscale address. The `cloudflared` service gives the **webhook endpoint only** a public entry point.
+
+- **Service:** `cloudflared` — a Cloudflare Tunnel connector running in the compose network.
+- **What for:** exposes a single public hostname (e.g. `qbo-webhooks.<your-domain>`) that forwards just the webhook path to Django.
+- **Why a tunnel:** the connector makes an outbound-only connection to Cloudflare — no inbound firewall ports and no public IP on the host, and TLS terminates at Cloudflare's edge. The rest of the portal stays Tailscale-only.
+
+Request path: `Intuit → Cloudflare edge → cloudflared → web:8000`.
+
+Setup (one-time):
+
+1. In the Cloudflare Zero Trust dashboard (Networks → Tunnels), create a tunnel and copy its **token**.
+2. Add a **Public Hostname** to the tunnel:
+   - Hostname: `qbo-webhooks.<your-domain>`
+   - Path: `epos-qbo/webhooks/quickbooks` (restricts public access to the webhook only; everything else returns 404)
+   - Service: `HTTP` → `web:8000`
+
+   Cloudflare creates the proxied DNS record automatically.
+3. In `.env`, set `CLOUDFLARE_TUNNEL_TOKEN` and add the webhook hostname to `DJANGO_ALLOWED_HOSTS`.
+4. `docker compose up -d cloudflared` and recreate `web` so it picks up the new allowed host.
+5. Register the public URL in the Intuit app: `https://qbo-webhooks.<your-domain>/epos-qbo/webhooks/quickbooks/`.
+
+> On a Windows / Docker Desktop host, pull images from the interactive console before running `docker compose up` over SSH — the credential helper cannot run in a non-interactive session.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,8 @@ Retention/lifecycle plan: [`docs/ARTIFACT_RETENTION_PLAN.md`](docs/ARTIFACT_RETE
 - QBO: `QBO_CLIENT_ID`, `QBO_CLIENT_SECRET`
 - EPOS: credentials are referenced per-company via `epos.username_env_key` / `epos.password_env_key`
 - Portal: `DJANGO_SECRET_KEY`, `DJANGO_ALLOWED_HOSTS`, `DJANGO_CSRF_TRUSTED_ORIGINS` (when behind TLS proxy)
-- Slack: webhook URL env keys are referenced per-company
+- QuickBooks webhooks: `QBO_WEBHOOK_VERIFIER_TOKEN`; register `https://<portal-domain>/epos-qbo/webhooks/quickbooks/` in Intuit; Slack destinations use `QBO_WEBHOOK_SLACK_URL_COMPANY_A/B`
+- Slack: webhook URL env keys are referenced per-company, e.g. `SLACK_WEBHOOK_URL_A`
 - Portal base URL/domain is used for run links in operator output (Docker uses `PORTAL_DOMAIN`)
 
 ### Company configs (DB + JSON)

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -17,6 +17,7 @@ class LoginRequiredMiddleware:
             "/logout/",
             "/admin/",  # Django admin handles its own auth
             "/static/",
+            "/epos-qbo/webhooks/quickbooks/",
         )
         path = request.path
         if not request.user.is_authenticated and not any(path.startswith(p) for p in public_prefixes):

--- a/apps/core/middleware.py
+++ b/apps/core/middleware.py
@@ -18,6 +18,7 @@ class LoginRequiredMiddleware:
             "/admin/",  # Django admin handles its own auth
             "/static/",
             "/epos-qbo/webhooks/quickbooks/",
+            "/epos-qbo/webhooks/quickbooks",
         )
         path = request.path
         if not request.user.is_authenticated and not any(path.startswith(p) for p in public_prefixes):

--- a/apps/epos_qbo/migrations/0017_qbowebhookevent.py
+++ b/apps/epos_qbo/migrations/0017_qbowebhookevent.py
@@ -1,0 +1,66 @@
+from django.db import migrations, models
+import django.utils.timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("epos_qbo", "0016_inventoryreviewacknowledgement"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="QboWebhookEvent",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("received_at", models.DateTimeField(default=django.utils.timezone.now)),
+                ("signature_valid", models.BooleanField(default=False)),
+                ("realm_id", models.CharField(blank=True, max_length=64)),
+                ("company_key", models.SlugField(blank=True, max_length=64)),
+                ("company_display_name", models.CharField(blank=True, max_length=255)),
+                ("entity_name", models.CharField(blank=True, max_length=64)),
+                ("entity_id", models.CharField(blank=True, max_length=64)),
+                ("operation", models.CharField(blank=True, max_length=32)),
+                ("last_updated", models.CharField(blank=True, max_length=64)),
+                ("is_test_event", models.BooleanField(default=False)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("received", "Received"),
+                            ("sent", "Sent"),
+                            ("skipped", "Skipped"),
+                            ("failed", "Failed"),
+                            ("rejected", "Rejected"),
+                        ],
+                        default="received",
+                        max_length=16,
+                    ),
+                ),
+                ("slack_webhook_configured", models.BooleanField(default=False)),
+                ("slack_sent", models.BooleanField(default=False)),
+                ("skip_reason", models.TextField(blank=True)),
+                ("error_message", models.TextField(blank=True)),
+                ("payload_json", models.JSONField(blank=True, default=dict)),
+            ],
+            options={
+                "ordering": ["-received_at", "-id"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="qbowebhookevent",
+            index=models.Index(fields=["-received_at"], name="epos_qbo_qb_receive_4c8581_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="qbowebhookevent",
+            index=models.Index(fields=["realm_id", "-received_at"], name="epos_qbo_qb_realm_i_79ede4_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="qbowebhookevent",
+            index=models.Index(fields=["company_key", "-received_at"], name="epos_qbo_qb_company_4e1890_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="qbowebhookevent",
+            index=models.Index(fields=["status", "-received_at"], name="epos_qbo_qb_status_7b550d_idx"),
+        ),
+    ]

--- a/apps/epos_qbo/models.py
+++ b/apps/epos_qbo/models.py
@@ -246,6 +246,52 @@ class CompanyConfigRecord(models.Model):
         return f"{self.company_key} ({self.display_name})"
 
 
+class QboWebhookEvent(models.Model):
+    STATUS_RECEIVED = "received"
+    STATUS_SENT = "sent"
+    STATUS_SKIPPED = "skipped"
+    STATUS_FAILED = "failed"
+    STATUS_REJECTED = "rejected"
+    STATUS_CHOICES = [
+        (STATUS_RECEIVED, "Received"),
+        (STATUS_SENT, "Sent"),
+        (STATUS_SKIPPED, "Skipped"),
+        (STATUS_FAILED, "Failed"),
+        (STATUS_REJECTED, "Rejected"),
+    ]
+
+    received_at = models.DateTimeField(default=timezone.now)
+    signature_valid = models.BooleanField(default=False)
+    realm_id = models.CharField(max_length=64, blank=True)
+    company_key = models.SlugField(max_length=64, blank=True)
+    company_display_name = models.CharField(max_length=255, blank=True)
+    entity_name = models.CharField(max_length=64, blank=True)
+    entity_id = models.CharField(max_length=64, blank=True)
+    operation = models.CharField(max_length=32, blank=True)
+    last_updated = models.CharField(max_length=64, blank=True)
+    is_test_event = models.BooleanField(default=False)
+    status = models.CharField(max_length=16, choices=STATUS_CHOICES, default=STATUS_RECEIVED)
+    slack_webhook_configured = models.BooleanField(default=False)
+    slack_sent = models.BooleanField(default=False)
+    skip_reason = models.TextField(blank=True)
+    error_message = models.TextField(blank=True)
+    payload_json = models.JSONField(default=dict, blank=True)
+
+    class Meta:
+        ordering = ["-received_at", "-id"]
+        indexes = [
+            models.Index(fields=["-received_at"]),
+            models.Index(fields=["realm_id", "-received_at"]),
+            models.Index(fields=["company_key", "-received_at"]),
+            models.Index(fields=["status", "-received_at"]),
+        ]
+
+    def __str__(self) -> str:
+        entity = self.entity_name or "Webhook"
+        operation = self.operation or self.status
+        return f"{entity} {operation} ({self.received_at:%Y-%m-%d %H:%M:%S})"
+
+
 class RunJob(models.Model):
     SCOPE_SINGLE = "single_company"
     SCOPE_ALL = "all_companies"

--- a/apps/epos_qbo/services/qbo_webhook_notifications.py
+++ b/apps/epos_qbo/services/qbo_webhook_notifications.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import requests
+
+from code_scripts.company_config import get_qbo_api_base_url
+from code_scripts.slack_notify import send_slack_success
+from code_scripts.token_manager import get_access_token
+
+from ..models import CompanyConfigRecord
+
+logger = logging.getLogger(__name__)
+
+QBO_MINOR_VERSION = "70"
+QBO_LOOKUP_TIMEOUT_SECS = 12
+
+
+@dataclass(frozen=True)
+class WebhookEntity:
+    name: str
+    entity_id: str
+    operation: str
+    last_updated: str
+
+
+def process_qbo_webhook_payload(payload: dict[str, Any]) -> int:
+    """Process Intuit data-change webhooks and forward Slack notifications."""
+    notifications = payload.get("eventNotifications")
+    if not isinstance(notifications, list):
+        logger.warning("QBO webhook ignored: missing eventNotifications list")
+        return 0
+
+    sent_count = 0
+    for notification in notifications:
+        if not isinstance(notification, dict):
+            continue
+        realm_id = str(notification.get("realmId") or "").strip()
+        if not realm_id:
+            logger.warning("QBO webhook notification skipped: missing realmId")
+            continue
+        company = _find_company_by_realm_id(realm_id)
+        if company is None:
+            logger.warning("QBO webhook notification skipped: unknown realmId=%s", realm_id)
+            continue
+        webhook_url = _company_slack_webhook(company.company_key)
+        if not webhook_url:
+            logger.info("QBO webhook Slack skipped for %s: no webhook configured", company.company_key)
+            continue
+
+        for entity in _iter_entities(notification):
+            message = _format_entity_notification(company=company, realm_id=realm_id, entity=entity)
+            send_slack_success(message, webhook_url)
+            sent_count += 1
+    return sent_count
+
+
+def _find_company_by_realm_id(realm_id: str) -> CompanyConfigRecord | None:
+    for company in CompanyConfigRecord.objects.filter(is_active=True):
+        qbo = company.config_json.get("qbo") if isinstance(company.config_json, dict) else {}
+        if isinstance(qbo, dict) and str(qbo.get("realm_id") or "").strip() == realm_id:
+            return company
+    return None
+
+
+def _company_slack_webhook(company_key: str) -> str:
+    key_suffix = company_key.upper().replace("-", "_")
+    company_specific = os.getenv(f"QBO_WEBHOOK_SLACK_URL_{key_suffix}", "").strip()
+    if company_specific:
+        return company_specific
+    return os.getenv("QBO_WEBHOOK_SLACK_URL", "").strip()
+
+
+def _iter_entities(notification: dict[str, Any]) -> list[WebhookEntity]:
+    data_change = notification.get("dataChangeEvent")
+    if not isinstance(data_change, dict):
+        return []
+    entities = data_change.get("entities")
+    if not isinstance(entities, list):
+        return []
+    out: list[WebhookEntity] = []
+    for raw in entities:
+        if not isinstance(raw, dict):
+            continue
+        name = str(raw.get("name") or "").strip()
+        entity_id = str(raw.get("id") or "").strip()
+        if not name or not entity_id:
+            continue
+        out.append(
+            WebhookEntity(
+                name=name,
+                entity_id=entity_id,
+                operation=str(raw.get("operation") or "").strip() or "Unknown",
+                last_updated=str(raw.get("lastUpdated") or "").strip(),
+            )
+        )
+    return out
+
+
+def _format_entity_notification(
+    *,
+    company: CompanyConfigRecord,
+    realm_id: str,
+    entity: WebhookEntity,
+) -> str:
+    if entity.name == "Item":
+        return _format_item_notification(company=company, realm_id=realm_id, entity=entity)
+    return _format_generic_notification(company=company, realm_id=realm_id, entity=entity)
+
+
+def _format_generic_notification(
+    *,
+    company: CompanyConfigRecord,
+    realm_id: str,
+    entity: WebhookEntity,
+    detail_note: str = "",
+) -> str:
+    lines = [
+        f"*QuickBooks {entity.name} {entity.operation}*",
+        f"• Company: {company.display_name}",
+        f"• Realm ID: `{realm_id}`",
+        f"• Entity ID: `{entity.entity_id}`",
+    ]
+    if entity.last_updated:
+        lines.append(f"• Updated: {entity.last_updated}")
+    if detail_note:
+        lines.append(f"• Details: {detail_note}")
+    return "\n".join(lines)
+
+
+def _format_item_notification(
+    *,
+    company: CompanyConfigRecord,
+    realm_id: str,
+    entity: WebhookEntity,
+) -> str:
+    item, error = _fetch_qbo_item(company=company, realm_id=realm_id, item_id=entity.entity_id)
+    if error:
+        return _format_generic_notification(
+            company=company,
+            realm_id=realm_id,
+            entity=entity,
+            detail_note=f"Item lookup unavailable ({error}).",
+        )
+    if not item:
+        return _format_generic_notification(
+            company=company,
+            realm_id=realm_id,
+            entity=entity,
+            detail_note="QuickBooks returned no Item details.",
+        )
+
+    item_name = str(item.get("Name") or item.get("FullyQualifiedName") or entity.entity_id).strip()
+    item_type = str(item.get("Type") or "Unknown").strip()
+    lines = [
+        f"*QuickBooks Item {entity.operation}*",
+        f"• Company: {company.display_name}",
+        f"• Item: {item_name}",
+        f"• Type: {item_type}",
+        f"• Entity ID: `{entity.entity_id}`",
+    ]
+
+    for label, value in [
+        ("Fully qualified name", item.get("FullyQualifiedName")),
+        ("Active", _yes_no(item.get("Active"))),
+        ("Track quantity", _yes_no(item.get("TrackQtyOnHand"))),
+        ("Quantity on hand", item.get("QtyOnHand")),
+        ("Inventory start date", item.get("InvStartDate")),
+        ("Unit price", item.get("UnitPrice")),
+        ("Purchase cost", item.get("PurchaseCost")),
+        ("Parent", _ref_name(item.get("ParentRef"))),
+        ("Income account", _ref_name(item.get("IncomeAccountRef"))),
+        ("Asset account", _ref_name(item.get("AssetAccountRef"))),
+        ("Expense account", _ref_name(item.get("ExpenseAccountRef"))),
+    ]:
+        if value not in (None, ""):
+            lines.append(f"• {label}: {value}")
+    if entity.last_updated:
+        lines.append(f"• Updated: {entity.last_updated}")
+    return "\n".join(lines)
+
+
+def _fetch_qbo_item(
+    *,
+    company: CompanyConfigRecord,
+    realm_id: str,
+    item_id: str,
+) -> tuple[dict[str, Any] | None, str]:
+    config = company.config_json if isinstance(company.config_json, dict) else {}
+    qbo = config.get("qbo") if isinstance(config.get("qbo"), dict) else {}
+    environment = str(qbo.get("environment") or "production")
+    try:
+        access_token = get_access_token(company.company_key, realm_id)
+    except Exception as exc:
+        return None, str(exc)
+
+    base_url = get_qbo_api_base_url(environment)
+    url = f"{base_url}/v3/company/{realm_id}/item/{item_id}"
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+    }
+    params = {"minorversion": QBO_MINOR_VERSION}
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=QBO_LOOKUP_TIMEOUT_SECS)
+    except requests.Timeout:
+        return None, "QuickBooks item lookup timed out"
+    except requests.RequestException as exc:
+        return None, f"QuickBooks network error: {exc}"
+    if resp.status_code != 200:
+        return None, f"QuickBooks returned HTTP {resp.status_code}"
+    try:
+        payload = resp.json()
+    except ValueError:
+        return None, "QuickBooks returned invalid JSON"
+    item = payload.get("Item")
+    return (item if isinstance(item, dict) else None), ""
+
+
+def _ref_name(value: Any) -> str:
+    if not isinstance(value, dict):
+        return ""
+    name = str(value.get("name") or "").strip()
+    ref_id = str(value.get("value") or "").strip()
+    if name and ref_id:
+        return f"{name} (`{ref_id}`)"
+    return name or ref_id
+
+
+def _yes_no(value: Any) -> str:
+    if value is True:
+        return "Yes"
+    if value is False:
+        return "No"
+    return ""

--- a/apps/epos_qbo/services/qbo_webhook_notifications.py
+++ b/apps/epos_qbo/services/qbo_webhook_notifications.py
@@ -11,12 +11,13 @@ from code_scripts.company_config import get_qbo_api_base_url
 from code_scripts.slack_notify import send_slack_success
 from code_scripts.token_manager import get_access_token
 
-from ..models import CompanyConfigRecord
+from ..models import CompanyConfigRecord, QboWebhookEvent
 
 logger = logging.getLogger(__name__)
 
 QBO_MINOR_VERSION = "70"
 QBO_LOOKUP_TIMEOUT_SECS = 12
+INTUIT_TEST_REALM_ID = "310687"
 
 
 @dataclass(frozen=True)
@@ -43,18 +44,43 @@ def process_qbo_webhook_payload(payload: dict[str, Any]) -> int:
             logger.warning("QBO webhook notification skipped: missing realmId")
             continue
         company = _find_company_by_realm_id(realm_id)
-        if company is None:
-            logger.warning("QBO webhook notification skipped: unknown realmId=%s", realm_id)
-            continue
-        webhook_url = _company_slack_webhook(company.company_key)
-        if not webhook_url:
-            logger.info("QBO webhook Slack skipped for %s: no webhook configured", company.company_key)
-            continue
+        is_test_event = realm_id == INTUIT_TEST_REALM_ID
+        webhook_url = _company_slack_webhook(company.company_key if company else "", is_test_event=is_test_event)
 
         for entity in _iter_entities(notification):
-            message = _format_entity_notification(company=company, realm_id=realm_id, entity=entity)
-            send_slack_success(message, webhook_url)
-            sent_count += 1
+            event_log = _create_event_log(
+                notification=notification,
+                entity=entity,
+                realm_id=realm_id,
+                company=company,
+                is_test_event=is_test_event,
+                slack_webhook_configured=bool(webhook_url),
+            )
+            if company is None and not is_test_event:
+                logger.warning("QBO webhook notification skipped: unknown realmId=%s", realm_id)
+                _mark_event_skipped(event_log, f"Unknown realmId: {realm_id}")
+                continue
+            if not webhook_url:
+                target = company.company_key if company else "test event"
+                logger.info("QBO webhook Slack skipped for %s: no webhook configured", target)
+                _mark_event_skipped(event_log, "No QBO webhook Slack URL configured.")
+                continue
+
+            message = _format_entity_notification(
+                company=company,
+                realm_id=realm_id,
+                entity=entity,
+                is_test_event=is_test_event,
+            )
+            try:
+                send_slack_success(message, webhook_url)
+            except Exception as exc:  # pragma: no cover - send_slack_success currently swallows errors
+                _mark_event_failed(event_log, str(exc))
+            else:
+                event_log.status = QboWebhookEvent.STATUS_SENT
+                event_log.slack_sent = True
+                event_log.save(update_fields=["status", "slack_sent"])
+                sent_count += 1
     return sent_count
 
 
@@ -66,12 +92,66 @@ def _find_company_by_realm_id(realm_id: str) -> CompanyConfigRecord | None:
     return None
 
 
-def _company_slack_webhook(company_key: str) -> str:
-    key_suffix = company_key.upper().replace("-", "_")
-    company_specific = os.getenv(f"QBO_WEBHOOK_SLACK_URL_{key_suffix}", "").strip()
-    if company_specific:
-        return company_specific
+def _company_slack_webhook(company_key: str, *, is_test_event: bool = False) -> str:
+    if is_test_event:
+        test_webhook = os.getenv("QBO_WEBHOOK_SLACK_URL_TEST", "").strip()
+        if test_webhook:
+            return test_webhook
+        company_a_webhook = os.getenv("QBO_WEBHOOK_SLACK_URL_COMPANY_A", "").strip()
+        if company_a_webhook:
+            return company_a_webhook
+    if company_key:
+        key_suffix = company_key.upper().replace("-", "_")
+        company_specific = os.getenv(f"QBO_WEBHOOK_SLACK_URL_{key_suffix}", "").strip()
+        if company_specific:
+            return company_specific
     return os.getenv("QBO_WEBHOOK_SLACK_URL", "").strip()
+
+
+def _create_event_log(
+    *,
+    notification: dict[str, Any],
+    entity: WebhookEntity,
+    realm_id: str,
+    company: CompanyConfigRecord | None,
+    is_test_event: bool,
+    slack_webhook_configured: bool,
+) -> QboWebhookEvent:
+    return QboWebhookEvent.objects.create(
+        signature_valid=True,
+        realm_id=realm_id,
+        company_key=company.company_key if company else "",
+        company_display_name=company.display_name if company else ("Intuit test event" if is_test_event else ""),
+        entity_name=entity.name,
+        entity_id=entity.entity_id,
+        operation=entity.operation,
+        last_updated=entity.last_updated,
+        is_test_event=is_test_event,
+        status=QboWebhookEvent.STATUS_RECEIVED,
+        slack_webhook_configured=slack_webhook_configured,
+        payload_json=notification,
+    )
+
+
+def record_rejected_webhook(*, reason: str, payload: dict[str, Any] | None = None) -> None:
+    QboWebhookEvent.objects.create(
+        signature_valid=False,
+        status=QboWebhookEvent.STATUS_REJECTED,
+        skip_reason=reason,
+        payload_json=payload or {},
+    )
+
+
+def _mark_event_skipped(event_log: QboWebhookEvent, reason: str) -> None:
+    event_log.status = QboWebhookEvent.STATUS_SKIPPED
+    event_log.skip_reason = reason
+    event_log.save(update_fields=["status", "skip_reason"])
+
+
+def _mark_event_failed(event_log: QboWebhookEvent, message: str) -> None:
+    event_log.status = QboWebhookEvent.STATUS_FAILED
+    event_log.error_message = message
+    event_log.save(update_fields=["status", "error_message"])
 
 
 def _iter_entities(notification: dict[str, Any]) -> list[WebhookEntity]:
@@ -102,13 +182,29 @@ def _iter_entities(notification: dict[str, Any]) -> list[WebhookEntity]:
 
 def _format_entity_notification(
     *,
-    company: CompanyConfigRecord,
+    company: CompanyConfigRecord | None,
     realm_id: str,
     entity: WebhookEntity,
+    is_test_event: bool = False,
 ) -> str:
+    if is_test_event:
+        return _format_test_notification(realm_id=realm_id, entity=entity)
     if entity.name == "Item":
         return _format_item_notification(company=company, realm_id=realm_id, entity=entity)
     return _format_generic_notification(company=company, realm_id=realm_id, entity=entity)
+
+
+def _format_test_notification(*, realm_id: str, entity: WebhookEntity) -> str:
+    lines = [
+        f"*QuickBooks Test Event: {entity.name} {entity.operation}*",
+        "• Source: Intuit Developer send test events",
+        f"• Test Realm ID: `{realm_id}`",
+        f"• Entity ID: `{entity.entity_id}`",
+    ]
+    if entity.last_updated:
+        lines.append(f"• Updated: {entity.last_updated}")
+    lines.append("• Note: This is not a real company event.")
+    return "\n".join(lines)
 
 
 def _format_generic_notification(

--- a/apps/epos_qbo/services/qbo_webhook_notifications.py
+++ b/apps/epos_qbo/services/qbo_webhook_notifications.py
@@ -26,15 +26,35 @@ class WebhookEntity:
     entity_id: str
     operation: str
     last_updated: str
+    raw_event_id: str = ""
 
 
 def process_qbo_webhook_payload(payload: dict[str, Any]) -> int:
     """Process Intuit data-change webhooks and forward Slack notifications."""
+    if _is_cloudevents_payload(payload):
+        return _process_cloudevents_payload([payload])
+
     notifications = payload.get("eventNotifications")
     if not isinstance(notifications, list):
         logger.warning("QBO webhook ignored: missing eventNotifications list")
         return 0
+    return _process_data_change_notifications(notifications)
 
+
+def process_qbo_webhook_body(payload: Any) -> int:
+    """Process any supported Intuit webhook body shape."""
+    if isinstance(payload, list):
+        if all(isinstance(item, dict) for item in payload):
+            return _process_cloudevents_payload(payload)
+        logger.warning("QBO webhook ignored: array payload contained non-object entries")
+        return 0
+    if isinstance(payload, dict):
+        return process_qbo_webhook_payload(payload)
+    logger.warning("QBO webhook ignored: unsupported payload type %s", type(payload).__name__)
+    return 0
+
+
+def _process_data_change_notifications(notifications: list[dict[str, Any]]) -> int:
     sent_count = 0
     for notification in notifications:
         if not isinstance(notification, dict):
@@ -43,45 +63,83 @@ def process_qbo_webhook_payload(payload: dict[str, Any]) -> int:
         if not realm_id:
             logger.warning("QBO webhook notification skipped: missing realmId")
             continue
-        company = _find_company_by_realm_id(realm_id)
-        is_test_event = realm_id == INTUIT_TEST_REALM_ID
-        webhook_url = _company_slack_webhook(company.company_key if company else "", is_test_event=is_test_event)
-
-        for entity in _iter_entities(notification):
-            event_log = _create_event_log(
-                notification=notification,
-                entity=entity,
-                realm_id=realm_id,
-                company=company,
-                is_test_event=is_test_event,
-                slack_webhook_configured=bool(webhook_url),
-            )
-            if company is None and not is_test_event:
-                logger.warning("QBO webhook notification skipped: unknown realmId=%s", realm_id)
-                _mark_event_skipped(event_log, f"Unknown realmId: {realm_id}")
-                continue
-            if not webhook_url:
-                target = company.company_key if company else "test event"
-                logger.info("QBO webhook Slack skipped for %s: no webhook configured", target)
-                _mark_event_skipped(event_log, "No QBO webhook Slack URL configured.")
-                continue
-
-            message = _format_entity_notification(
-                company=company,
-                realm_id=realm_id,
-                entity=entity,
-                is_test_event=is_test_event,
-            )
-            try:
-                send_slack_success(message, webhook_url)
-            except Exception as exc:  # pragma: no cover - send_slack_success currently swallows errors
-                _mark_event_failed(event_log, str(exc))
-            else:
-                event_log.status = QboWebhookEvent.STATUS_SENT
-                event_log.slack_sent = True
-                event_log.save(update_fields=["status", "slack_sent"])
-                sent_count += 1
+        sent_count += _process_realm_entities(
+            realm_id=realm_id,
+            entities=_iter_entities(notification),
+            payload_for_log=notification,
+        )
     return sent_count
+
+
+def _process_cloudevents_payload(events: list[dict[str, Any]]) -> int:
+    sent_count = 0
+    for event in events:
+        realm_id = str(event.get("intuitaccountid") or "").strip()
+        if not realm_id:
+            logger.warning("QBO webhook CloudEvent skipped: missing intuitaccountid")
+            continue
+        entity = _entity_from_cloudevent(event)
+        if entity is None:
+            logger.warning("QBO webhook CloudEvent skipped: missing entity details")
+            continue
+        sent_count += _process_realm_entities(
+            realm_id=realm_id,
+            entities=[entity],
+            payload_for_log=event,
+        )
+    return sent_count
+
+
+def _process_realm_entities(
+    *,
+    realm_id: str,
+    entities: list[WebhookEntity],
+    payload_for_log: dict[str, Any],
+) -> int:
+    sent_count = 0
+    company = _find_company_by_realm_id(realm_id)
+    is_test_event = realm_id == INTUIT_TEST_REALM_ID
+    webhook_url = _company_slack_webhook(company.company_key if company else "", is_test_event=is_test_event)
+
+    for entity in entities:
+        event_log = _create_event_log(
+            notification=payload_for_log,
+            entity=entity,
+            realm_id=realm_id,
+            company=company,
+            is_test_event=is_test_event,
+            slack_webhook_configured=bool(webhook_url),
+        )
+        if company is None and not is_test_event:
+            logger.warning("QBO webhook notification skipped: unknown realmId=%s", realm_id)
+            _mark_event_skipped(event_log, f"Unknown realmId: {realm_id}")
+            continue
+        if not webhook_url:
+            target = company.company_key if company else "test event"
+            logger.info("QBO webhook Slack skipped for %s: no webhook configured", target)
+            _mark_event_skipped(event_log, "No QBO webhook Slack URL configured.")
+            continue
+
+        message = _format_entity_notification(
+            company=company,
+            realm_id=realm_id,
+            entity=entity,
+            is_test_event=is_test_event,
+        )
+        try:
+            send_slack_success(message, webhook_url)
+        except Exception as exc:  # pragma: no cover - send_slack_success currently swallows errors
+            _mark_event_failed(event_log, str(exc))
+        else:
+            event_log.status = QboWebhookEvent.STATUS_SENT
+            event_log.slack_sent = True
+            event_log.save(update_fields=["status", "slack_sent"])
+            sent_count += 1
+    return sent_count
+
+
+def _is_cloudevents_payload(payload: dict[str, Any]) -> bool:
+    return bool(payload.get("specversion") and payload.get("intuitaccountid"))
 
 
 def _find_company_by_realm_id(realm_id: str) -> CompanyConfigRecord | None:
@@ -178,6 +236,79 @@ def _iter_entities(notification: dict[str, Any]) -> list[WebhookEntity]:
             )
         )
     return out
+
+
+def _entity_from_cloudevent(event: dict[str, Any]) -> WebhookEntity | None:
+    entity_id = str(event.get("intuitentityid") or "").strip()
+    event_type = str(event.get("type") or "").strip()
+    entity_name, operation = _parse_cloudevent_type(event_type)
+    if not entity_id or not entity_name:
+        return None
+    return WebhookEntity(
+        name=entity_name,
+        entity_id=entity_id,
+        operation=operation or "Unknown",
+        last_updated=str(event.get("time") or "").strip(),
+        raw_event_id=str(event.get("id") or "").strip(),
+    )
+
+
+def _parse_cloudevent_type(event_type: str) -> tuple[str, str]:
+    # Expected shape: qbo.item.created.v1
+    parts = [p for p in event_type.split(".") if p]
+    if len(parts) < 4:
+        return "", ""
+    entity = _entity_name_from_slug(parts[1])
+    operation = _operation_from_slug(parts[2])
+    return entity, operation
+
+
+def _entity_name_from_slug(slug: str) -> str:
+    known = {
+        "account": "Account",
+        "bill": "Bill",
+        "billpayment": "BillPayment",
+        "budget": "Budget",
+        "class": "Class",
+        "creditmemo": "CreditMemo",
+        "currency": "Currency",
+        "customer": "Customer",
+        "department": "Department",
+        "deposit": "Deposit",
+        "employee": "Employee",
+        "estimate": "Estimate",
+        "invoice": "Invoice",
+        "item": "Item",
+        "journalcode": "JournalCode",
+        "journalentry": "JournalEntry",
+        "payment": "Payment",
+        "paymentmethod": "PaymentMethod",
+        "preferences": "Preferences",
+        "purchase": "Purchase",
+        "purchaseorder": "PurchaseOrder",
+        "refundreceipt": "RefundReceipt",
+        "salesreceipt": "SalesReceipt",
+        "taxagency": "TaxAgency",
+        "term": "Term",
+        "timeactivity": "TimeActivity",
+        "transfer": "Transfer",
+        "vendor": "Vendor",
+        "vendorcredit": "VendorCredit",
+    }
+    cleaned = slug.replace("_", "").replace("-", "").lower()
+    return known.get(cleaned, slug[:1].upper() + slug[1:])
+
+
+def _operation_from_slug(slug: str) -> str:
+    known = {
+        "created": "Create",
+        "updated": "Update",
+        "deleted": "Delete",
+        "merged": "Merge",
+        "voided": "Void",
+        "emailed": "Emailed",
+    }
+    return known.get(slug.lower(), slug[:1].upper() + slug[1:])
 
 
 def _format_entity_notification(

--- a/apps/epos_qbo/templates/epos_qbo/settings.html
+++ b/apps/epos_qbo/templates/epos_qbo/settings.html
@@ -124,6 +124,95 @@
         </form>
     </section>
 
+    <!-- QuickBooks event alerts -->
+    <section class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-xl p-6 shadow-sm">
+        <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between mb-4">
+            <div>
+                <h2 class="text-lg font-medium text-slate-900 dark:text-slate-100">QuickBooks event alerts</h2>
+                <p class="text-sm text-slate-600 dark:text-slate-400 mt-1">Webhook receiver status and recent event deliveries.</p>
+            </div>
+            <span class="inline-flex w-fit items-center rounded-md px-2 py-1 text-xs font-medium {% if qbo_webhook_status.verifier_configured %}bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300{% else %}bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300{% endif %}">
+                {% if qbo_webhook_status.verifier_configured %}Verifier configured{% else %}Verifier missing{% endif %}
+            </span>
+        </div>
+
+        <dl class="grid grid-cols-1 lg:grid-cols-2 gap-4 mb-6">
+            <div>
+                <dt class="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">Endpoint URL</dt>
+                <dd class="mt-1 text-sm text-slate-900 dark:text-slate-100 font-mono break-all">{{ qbo_webhook_status.endpoint_url }}</dd>
+            </div>
+            <div>
+                <dt class="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">Fallback Slack</dt>
+                <dd class="mt-1 text-sm {% if qbo_webhook_status.fallback_slack_configured %}text-emerald-700 dark:text-emerald-300{% else %}text-slate-600 dark:text-slate-300{% endif %}">
+                    {% if qbo_webhook_status.fallback_slack_configured %}Configured{% else %}Not configured{% endif %}
+                </dd>
+            </div>
+            <div>
+                <dt class="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">Test event Slack</dt>
+                <dd class="mt-1 text-sm {% if qbo_webhook_status.test_slack_configured %}text-emerald-700 dark:text-emerald-300{% else %}text-slate-600 dark:text-slate-300{% endif %}">
+                    {% if qbo_webhook_status.test_slack_configured %}Configured{% else %}Uses fallback or company webhook{% endif %}
+                </dd>
+            </div>
+            {% for destination in qbo_webhook_status.slack_destinations %}
+            <div>
+                <dt class="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">{{ destination.company.display_name }}</dt>
+                <dd class="mt-1 text-sm">
+                    <span class="font-mono text-slate-700 dark:text-slate-200">{{ destination.env_key }}</span>
+                    <span class="ml-2 {% if destination.configured %}text-emerald-700 dark:text-emerald-300{% else %}text-slate-500 dark:text-slate-400{% endif %}">
+                        {% if destination.configured %}configured{% else %}not configured{% endif %}
+                    </span>
+                </dd>
+            </div>
+            {% endfor %}
+        </dl>
+
+        <div class="overflow-x-auto border border-slate-200 dark:border-slate-700 rounded-lg">
+            <table class="min-w-full divide-y divide-slate-200 dark:divide-slate-700">
+                <thead class="bg-slate-50 dark:bg-slate-900/40">
+                    <tr>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">Received</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">Event</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">Company / realm</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">Status</th>
+                        <th class="px-4 py-3 text-left text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wider">Detail</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white dark:bg-slate-800 divide-y divide-slate-200 dark:divide-slate-700">
+                    {% for event in qbo_webhook_status.recent_events %}
+                    <tr>
+                        <td class="px-4 py-3 text-sm text-slate-600 dark:text-slate-300 whitespace-nowrap">{{ event.received_at|date:"M j, H:i:s" }}</td>
+                        <td class="px-4 py-3 text-sm text-slate-900 dark:text-slate-100">
+                            <div>{{ event.entity_name|default:"Webhook" }} {{ event.operation }}</div>
+                            {% if event.entity_id %}<div class="text-xs text-slate-500 dark:text-slate-400 font-mono">{{ event.entity_id }}</div>{% endif %}
+                            {% if event.is_test_event %}<div class="text-xs text-blue-600 dark:text-blue-300">TEST EVENT</div>{% endif %}
+                        </td>
+                        <td class="px-4 py-3 text-sm text-slate-600 dark:text-slate-300">
+                            <div>{{ event.company_display_name|default:"—" }}</div>
+                            <div class="text-xs font-mono text-slate-500 dark:text-slate-400">{{ event.realm_id|default:"—" }}</div>
+                        </td>
+                        <td class="px-4 py-3 text-sm">
+                            <span class="inline-flex rounded-md px-2 py-1 text-xs font-medium
+                                {% if event.status == 'sent' %}bg-emerald-50 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300
+                                {% elif event.status == 'failed' or event.status == 'rejected' %}bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-300
+                                {% elif event.status == 'skipped' %}bg-amber-50 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300
+                                {% else %}bg-slate-100 text-slate-700 dark:bg-slate-700 dark:text-slate-200{% endif %}">
+                                {{ event.get_status_display }}
+                            </span>
+                        </td>
+                        <td class="px-4 py-3 text-sm text-slate-600 dark:text-slate-300 max-w-md">
+                            {{ event.skip_reason|default:event.error_message|default:"—" }}
+                        </td>
+                    </tr>
+                    {% empty %}
+                    <tr>
+                        <td colspan="5" class="px-4 py-8 text-center text-sm text-slate-500 dark:text-slate-400">No QuickBooks webhook events received yet.</td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    </section>
+
     <!-- Dashboard (read-only effective values) -->
     <section class="bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-600 rounded-xl p-6 shadow-sm">
         <h2 class="text-lg font-medium text-slate-900 dark:text-slate-100 mb-4">Dashboard (effective values)</h2>

--- a/apps/epos_qbo/tests/test_qbo_webhooks.py
+++ b/apps/epos_qbo/tests/test_qbo_webhooks.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from unittest import mock
+
+from django.test import Client, TestCase
+from django.urls import reverse
+
+from apps.epos_qbo.models import CompanyConfigRecord
+
+
+def _signature(body: bytes, token: str) -> str:
+    digest = hmac.new(token.encode("utf-8"), body, hashlib.sha256).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+class QuickBooksWebhookViewTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.url = reverse("epos_qbo:quickbooks-webhook")
+        self.token = "test-verifier-token"
+
+    def _post(self, payload: dict, *, token: str | None = None):
+        body = json.dumps(payload).encode("utf-8")
+        verifier = token if token is not None else self.token
+        return self.client.post(
+            self.url,
+            data=body,
+            content_type="application/json",
+            HTTP_INTUIT_SIGNATURE=_signature(body, verifier),
+        )
+
+    @mock.patch.dict("os.environ", {"QBO_WEBHOOK_VERIFIER_TOKEN": "test-verifier-token"})
+    @mock.patch("apps.epos_qbo.webhooks.process_qbo_webhook_payload", return_value=2)
+    def test_valid_signature_processes_payload_without_login(self, process_payload):
+        response = self._post({"eventNotifications": []})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["notifications_sent"], 2)
+        process_payload.assert_called_once_with({"eventNotifications": []})
+
+    @mock.patch.dict("os.environ", {"QBO_WEBHOOK_VERIFIER_TOKEN": "test-verifier-token"})
+    @mock.patch("apps.epos_qbo.webhooks.process_qbo_webhook_payload")
+    def test_invalid_signature_rejected(self, process_payload):
+        response = self._post({"eventNotifications": []}, token="wrong-token")
+        self.assertEqual(response.status_code, 401)
+        process_payload.assert_not_called()
+
+    @mock.patch.dict("os.environ", {}, clear=True)
+    def test_missing_verifier_token_is_service_unavailable(self):
+        response = self.client.post(self.url, data=b"{}", content_type="application/json")
+        self.assertEqual(response.status_code, 503)
+
+
+class QuickBooksWebhookNotificationTests(TestCase):
+    def setUp(self):
+        self.company = CompanyConfigRecord.objects.create(
+            company_key="company_a",
+            display_name="Oreva Innovations & Tech",
+            config_json={
+                "company_key": "company_a",
+                "display_name": "Oreva Innovations & Tech",
+                "qbo": {"realm_id": "9341455406194328", "environment": "production"},
+            },
+        )
+        self.payload = {
+            "eventNotifications": [
+                {
+                    "realmId": "9341455406194328",
+                    "dataChangeEvent": {
+                        "entities": [
+                            {
+                                "name": "Item",
+                                "id": "14895",
+                                "operation": "Create",
+                                "lastUpdated": "2026-06-11T18:55:00.000Z",
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.requests.get")
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.get_access_token", return_value="access")
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.send_slack_success")
+    @mock.patch.dict(
+        "os.environ",
+        {"QBO_WEBHOOK_SLACK_URL_COMPANY_A": "https://hooks.slack.test/qbo-company-a"},
+    )
+    def test_item_event_sends_enriched_slack(self, send_slack, _get_token, requests_get):
+        requests_get.return_value = mock.Mock(
+            status_code=200,
+            json=lambda: {
+                "Item": {
+                    "Name": "Coke 50CL",
+                    "Type": "Inventory",
+                    "Active": True,
+                    "TrackQtyOnHand": True,
+                    "FullyQualifiedName": "Drinks:Coke 50CL",
+                    "IncomeAccountRef": {"name": "Product Sales", "value": "91"},
+                    "AssetAccountRef": {"name": "Inventory Asset", "value": "92"},
+                }
+            },
+        )
+
+        from apps.epos_qbo.services.qbo_webhook_notifications import process_qbo_webhook_payload
+
+        sent_count = process_qbo_webhook_payload(self.payload)
+
+        self.assertEqual(sent_count, 1)
+        send_slack.assert_called_once()
+        message, webhook = send_slack.call_args.args
+        self.assertEqual(webhook, "https://hooks.slack.test/qbo-company-a")
+        self.assertIn("QuickBooks Item Create", message)
+        self.assertIn("Oreva Innovations & Tech", message)
+        self.assertIn("Coke 50CL", message)
+        self.assertIn("Inventory", message)
+        self.assertIn("Product Sales", message)
+
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.send_slack_success")
+    @mock.patch.dict("os.environ", {"QBO_WEBHOOK_SLACK_URL": "https://hooks.slack.test/qbo-default"})
+    def test_non_item_event_sends_generic_slack(self, send_slack):
+        payload = {
+            "eventNotifications": [
+                {
+                    "realmId": "9341455406194328",
+                    "dataChangeEvent": {
+                        "entities": [
+                            {
+                                "name": "Customer",
+                                "id": "42",
+                                "operation": "Update",
+                                "lastUpdated": "2026-06-11T19:00:00.000Z",
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+
+        from apps.epos_qbo.services.qbo_webhook_notifications import process_qbo_webhook_payload
+
+        sent_count = process_qbo_webhook_payload(payload)
+
+        self.assertEqual(sent_count, 1)
+        message = send_slack.call_args.args[0]
+        self.assertIn("QuickBooks Customer Update", message)
+        self.assertIn("Entity ID: `42`", message)
+
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.send_slack_success")
+    @mock.patch.dict("os.environ", {"QBO_WEBHOOK_SLACK_URL": "https://hooks.slack.test/qbo-default"})
+    def test_unknown_realm_sends_no_slack(self, send_slack):
+        payload = {
+            "eventNotifications": [
+                {
+                    "realmId": "unknown",
+                    "dataChangeEvent": {"entities": [{"name": "Item", "id": "1", "operation": "Create"}]},
+                }
+            ]
+        }
+
+        from apps.epos_qbo.services.qbo_webhook_notifications import process_qbo_webhook_payload
+
+        self.assertEqual(process_qbo_webhook_payload(payload), 0)
+        send_slack.assert_not_called()
+
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.send_slack_success")
+    @mock.patch.dict("os.environ", {"SLACK_WEBHOOK_URL_A": "https://hooks.slack.test/pipeline"}, clear=True)
+    def test_pipeline_slack_env_is_not_used_for_qbo_webhooks(self, send_slack):
+        from apps.epos_qbo.services.qbo_webhook_notifications import process_qbo_webhook_payload
+
+        self.assertEqual(process_qbo_webhook_payload(self.payload), 0)
+        send_slack.assert_not_called()

--- a/apps/epos_qbo/tests/test_qbo_webhooks.py
+++ b/apps/epos_qbo/tests/test_qbo_webhooks.py
@@ -34,7 +34,7 @@ class QuickBooksWebhookViewTests(TestCase):
         )
 
     @mock.patch.dict("os.environ", {"QBO_WEBHOOK_VERIFIER_TOKEN": "test-verifier-token"})
-    @mock.patch("apps.epos_qbo.webhooks.process_qbo_webhook_payload", return_value=2)
+    @mock.patch("apps.epos_qbo.webhooks.process_qbo_webhook_body", return_value=2)
     def test_valid_signature_processes_payload_without_login(self, process_payload):
         response = self._post({"eventNotifications": []})
         self.assertEqual(response.status_code, 200)
@@ -42,7 +42,7 @@ class QuickBooksWebhookViewTests(TestCase):
         process_payload.assert_called_once_with({"eventNotifications": []})
 
     @mock.patch.dict("os.environ", {"QBO_WEBHOOK_VERIFIER_TOKEN": "test-verifier-token"})
-    @mock.patch("apps.epos_qbo.webhooks.process_qbo_webhook_payload")
+    @mock.patch("apps.epos_qbo.webhooks.process_qbo_webhook_body")
     def test_invalid_signature_rejected(self, process_payload):
         response = self._post({"eventNotifications": []}, token="wrong-token")
         self.assertEqual(response.status_code, 401)
@@ -56,6 +56,24 @@ class QuickBooksWebhookViewTests(TestCase):
     def test_missing_verifier_token_is_service_unavailable(self):
         response = self.client.post(self.url, data=b"{}", content_type="application/json")
         self.assertEqual(response.status_code, 503)
+
+    @mock.patch.dict("os.environ", {"QBO_WEBHOOK_VERIFIER_TOKEN": "test-verifier-token"})
+    @mock.patch("apps.epos_qbo.webhooks.process_qbo_webhook_body", return_value=1)
+    def test_cloudevents_array_payload_is_accepted(self, process_payload):
+        payload = [
+            {
+                "specversion": "1.0",
+                "id": "event-1",
+                "type": "qbo.item.created.v1",
+                "time": "2026-06-12T15:52:10Z",
+                "intuitentityid": "14895",
+                "intuitaccountid": "9341455406194328",
+                "data": {},
+            }
+        ]
+        response = self._post(payload)
+        self.assertEqual(response.status_code, 200)
+        process_payload.assert_called_once_with(payload)
 
 
 class QuickBooksWebhookNotificationTests(TestCase):
@@ -130,6 +148,49 @@ class QuickBooksWebhookNotificationTests(TestCase):
         self.assertEqual(event.realm_id, "9341455406194328")
         self.assertEqual(event.company_key, "company_a")
         self.assertEqual(event.entity_name, "Item")
+
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.requests.get")
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.get_access_token", return_value="access")
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.send_slack_success")
+    @mock.patch.dict(
+        "os.environ",
+        {"QBO_WEBHOOK_SLACK_URL_COMPANY_A": "https://hooks.slack.test/qbo-company-a"},
+    )
+    def test_cloudevents_item_event_sends_enriched_slack(self, send_slack, _get_token, requests_get):
+        requests_get.return_value = mock.Mock(
+            status_code=200,
+            json=lambda: {
+                "Item": {
+                    "Name": "Test Product",
+                    "Type": "Inventory",
+                    "Active": True,
+                    "TrackQtyOnHand": True,
+                }
+            },
+        )
+        payload = [
+            {
+                "specversion": "1.0",
+                "id": "event-1",
+                "type": "qbo.item.created.v1",
+                "time": "2026-06-12T15:52:10Z",
+                "intuitentityid": "14895",
+                "intuitaccountid": "9341455406194328",
+                "data": {},
+            }
+        ]
+
+        from apps.epos_qbo.services.qbo_webhook_notifications import process_qbo_webhook_body
+
+        self.assertEqual(process_qbo_webhook_body(payload), 1)
+        message = send_slack.call_args.args[0]
+        self.assertIn("QuickBooks Item Create", message)
+        self.assertIn("Test Product", message)
+        event = QboWebhookEvent.objects.get()
+        self.assertEqual(event.realm_id, "9341455406194328")
+        self.assertEqual(event.entity_name, "Item")
+        self.assertEqual(event.operation, "Create")
+        self.assertEqual(event.entity_id, "14895")
 
     @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.send_slack_success")
     @mock.patch.dict("os.environ", {"QBO_WEBHOOK_SLACK_URL": "https://hooks.slack.test/qbo-default"})

--- a/apps/epos_qbo/tests/test_qbo_webhooks.py
+++ b/apps/epos_qbo/tests/test_qbo_webhooks.py
@@ -23,11 +23,11 @@ class QuickBooksWebhookViewTests(TestCase):
         self.url = reverse("epos_qbo:quickbooks-webhook")
         self.token = "test-verifier-token"
 
-    def _post(self, payload: dict, *, token: str | None = None):
+    def _post(self, payload: object, *, token: str | None = None, url: str | None = None):
         body = json.dumps(payload).encode("utf-8")
         verifier = token if token is not None else self.token
         return self.client.post(
-            self.url,
+            url or self.url,
             data=body,
             content_type="application/json",
             HTTP_INTUIT_SIGNATURE=_signature(body, verifier),
@@ -39,6 +39,14 @@ class QuickBooksWebhookViewTests(TestCase):
         response = self._post({"eventNotifications": []})
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()["notifications_sent"], 2)
+        process_payload.assert_called_once_with({"eventNotifications": []})
+
+    @mock.patch.dict("os.environ", {"QBO_WEBHOOK_VERIFIER_TOKEN": "test-verifier-token"})
+    @mock.patch("apps.epos_qbo.webhooks.process_qbo_webhook_body", return_value=1)
+    def test_no_slash_url_processes_payload_without_login(self, process_payload):
+        response = self._post({"eventNotifications": []}, url="/epos-qbo/webhooks/quickbooks")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["notifications_sent"], 1)
         process_payload.assert_called_once_with({"eventNotifications": []})
 
     @mock.patch.dict("os.environ", {"QBO_WEBHOOK_VERIFIER_TOKEN": "test-verifier-token"})

--- a/apps/epos_qbo/tests/test_qbo_webhooks.py
+++ b/apps/epos_qbo/tests/test_qbo_webhooks.py
@@ -9,7 +9,7 @@ from unittest import mock
 from django.test import Client, TestCase
 from django.urls import reverse
 
-from apps.epos_qbo.models import CompanyConfigRecord
+from apps.epos_qbo.models import CompanyConfigRecord, QboWebhookEvent
 
 
 def _signature(body: bytes, token: str) -> str:
@@ -47,6 +47,10 @@ class QuickBooksWebhookViewTests(TestCase):
         response = self._post({"eventNotifications": []}, token="wrong-token")
         self.assertEqual(response.status_code, 401)
         process_payload.assert_not_called()
+        event = QboWebhookEvent.objects.get()
+        self.assertEqual(event.status, QboWebhookEvent.STATUS_REJECTED)
+        self.assertFalse(event.signature_valid)
+        self.assertIn("Invalid Intuit signature", event.skip_reason)
 
     @mock.patch.dict("os.environ", {}, clear=True)
     def test_missing_verifier_token_is_service_unavailable(self):
@@ -119,6 +123,13 @@ class QuickBooksWebhookNotificationTests(TestCase):
         self.assertIn("Coke 50CL", message)
         self.assertIn("Inventory", message)
         self.assertIn("Product Sales", message)
+        event = QboWebhookEvent.objects.get()
+        self.assertEqual(event.status, QboWebhookEvent.STATUS_SENT)
+        self.assertTrue(event.signature_valid)
+        self.assertTrue(event.slack_sent)
+        self.assertEqual(event.realm_id, "9341455406194328")
+        self.assertEqual(event.company_key, "company_a")
+        self.assertEqual(event.entity_name, "Item")
 
     @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.send_slack_success")
     @mock.patch.dict("os.environ", {"QBO_WEBHOOK_SLACK_URL": "https://hooks.slack.test/qbo-default"})
@@ -166,6 +177,10 @@ class QuickBooksWebhookNotificationTests(TestCase):
 
         self.assertEqual(process_qbo_webhook_payload(payload), 0)
         send_slack.assert_not_called()
+        event = QboWebhookEvent.objects.get()
+        self.assertEqual(event.status, QboWebhookEvent.STATUS_SKIPPED)
+        self.assertEqual(event.realm_id, "unknown")
+        self.assertIn("Unknown realmId", event.skip_reason)
 
     @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.send_slack_success")
     @mock.patch.dict("os.environ", {"SLACK_WEBHOOK_URL_A": "https://hooks.slack.test/pipeline"}, clear=True)
@@ -174,3 +189,42 @@ class QuickBooksWebhookNotificationTests(TestCase):
 
         self.assertEqual(process_qbo_webhook_payload(self.payload), 0)
         send_slack.assert_not_called()
+        event = QboWebhookEvent.objects.get()
+        self.assertEqual(event.status, QboWebhookEvent.STATUS_SKIPPED)
+        self.assertIn("No QBO webhook Slack URL", event.skip_reason)
+
+    @mock.patch("apps.epos_qbo.services.qbo_webhook_notifications.send_slack_success")
+    @mock.patch.dict(
+        "os.environ",
+        {"QBO_WEBHOOK_SLACK_URL_COMPANY_A": "https://hooks.slack.test/qbo-company-a"},
+    )
+    def test_intuit_sample_realm_is_logged_and_sent_as_test_event(self, send_slack):
+        payload = {
+            "eventNotifications": [
+                {
+                    "realmId": "310687",
+                    "dataChangeEvent": {
+                        "entities": [
+                            {
+                                "name": "Item",
+                                "id": "1234",
+                                "operation": "Create",
+                                "lastUpdated": "2026-06-12T15:08:10.491Z",
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+
+        from apps.epos_qbo.services.qbo_webhook_notifications import process_qbo_webhook_payload
+
+        self.assertEqual(process_qbo_webhook_payload(payload), 1)
+        message, webhook = send_slack.call_args.args
+        self.assertEqual(webhook, "https://hooks.slack.test/qbo-company-a")
+        self.assertIn("QuickBooks Test Event", message)
+        self.assertIn("TEST", message.upper())
+        event = QboWebhookEvent.objects.get()
+        self.assertTrue(event.is_test_event)
+        self.assertEqual(event.status, QboWebhookEvent.STATUS_SENT)
+        self.assertEqual(event.realm_id, "310687")

--- a/apps/epos_qbo/urls.py
+++ b/apps/epos_qbo/urls.py
@@ -87,4 +87,5 @@ urlpatterns = [
     path("tools/qbo-query/", views.tools_qbo_query_api, name="tools-qbo-query"),
     path("tools/verify-mapping/", views.tools_verify_mapping_api, name="tools-verify-mapping"),
     path("webhooks/quickbooks/", webhooks.quickbooks_webhook, name="quickbooks-webhook"),
+    path("webhooks/quickbooks", webhooks.quickbooks_webhook, name="quickbooks-webhook-noslash"),
 ]

--- a/apps/epos_qbo/urls.py
+++ b/apps/epos_qbo/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 
-from . import views
+from . import views, webhooks
 
 app_name = "epos_qbo"
 
@@ -86,4 +86,5 @@ urlpatterns = [
     path("tools/", views.tools_page, name="tools"),
     path("tools/qbo-query/", views.tools_qbo_query_api, name="tools-qbo-query"),
     path("tools/verify-mapping/", views.tools_verify_mapping_api, name="tools-verify-mapping"),
+    path("webhooks/quickbooks/", webhooks.quickbooks_webhook, name="quickbooks-webhook"),
 ]

--- a/apps/epos_qbo/views.py
+++ b/apps/epos_qbo/views.py
@@ -53,6 +53,7 @@ from .models import (
     DashboardUserPreference,
     InventoryReviewAcknowledgement,
     PortalSettings,
+    QboWebhookEvent,
     RunArtifact,
     RunJob,
     RunSchedule,
@@ -1753,6 +1754,33 @@ def _scheduler_env_for_display():
     }
 
 
+def _qbo_webhook_status_context():
+    endpoint = "/epos-qbo/webhooks/quickbooks/"
+    base = str(getattr(settings, "OIAT_PORTAL_BASE_URL", "") or os.environ.get("PORTAL_DOMAIN", "")).strip()
+    if base and not base.startswith(("http://", "https://")):
+        base = f"https://{base}"
+    endpoint_url = f"{base.rstrip('/')}{endpoint}" if base else endpoint
+    active_companies = CompanyConfigRecord.objects.filter(is_active=True).order_by("company_key")
+    slack_destinations: list[dict[str, object]] = []
+    for company in active_companies:
+        env_key = f"QBO_WEBHOOK_SLACK_URL_{company.company_key.upper().replace('-', '_')}"
+        slack_destinations.append(
+            {
+                "company": company,
+                "env_key": env_key,
+                "configured": bool(os.environ.get(env_key, "").strip()),
+            }
+        )
+    return {
+        "endpoint_url": endpoint_url,
+        "verifier_configured": bool(os.environ.get("QBO_WEBHOOK_VERIFIER_TOKEN", "").strip()),
+        "fallback_slack_configured": bool(os.environ.get("QBO_WEBHOOK_SLACK_URL", "").strip()),
+        "test_slack_configured": bool(os.environ.get("QBO_WEBHOOK_SLACK_URL_TEST", "").strip()),
+        "slack_destinations": slack_destinations,
+        "recent_events": list(QboWebhookEvent.objects.all()[:10]),
+    }
+
+
 @login_required
 def settings_page(request):
     """Settings page: portal defaults (editable with can_manage_portal_settings), my preferences, dashboard and scheduler read-only."""
@@ -1818,6 +1846,7 @@ def settings_page(request):
         "reconcile_diff_warning": portal_settings.get_reconcile_diff_warning(),
         "reauth_guidance": portal_settings.get_reauth_guidance(),
         "scheduler_env": _scheduler_env_for_display(),
+        "qbo_webhook_status": _qbo_webhook_status_context(),
     }
     context.update(_nav_context())
     context.update(

--- a/apps/epos_qbo/webhooks.py
+++ b/apps/epos_qbo/webhooks.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+
+from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_POST
+
+from .services.qbo_webhook_notifications import process_qbo_webhook_payload
+
+logger = logging.getLogger(__name__)
+
+SIGNATURE_HEADER = "HTTP_INTUIT_SIGNATURE"
+VERIFIER_TOKEN_ENV = "QBO_WEBHOOK_VERIFIER_TOKEN"
+
+
+@csrf_exempt
+@require_POST
+def quickbooks_webhook(request: HttpRequest) -> HttpResponse:
+    verifier_token = os.getenv(VERIFIER_TOKEN_ENV, "").strip()
+    if not verifier_token:
+        logger.error("QBO webhook rejected: %s is not configured", VERIFIER_TOKEN_ENV)
+        return JsonResponse({"error": "webhook verifier not configured"}, status=503)
+
+    signature = request.META.get(SIGNATURE_HEADER, "")
+    if not _valid_intuit_signature(request.body, signature, verifier_token):
+        logger.warning("QBO webhook rejected: invalid Intuit signature")
+        return JsonResponse({"error": "invalid signature"}, status=401)
+
+    try:
+        payload = json.loads(request.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return JsonResponse({"error": "invalid JSON"}, status=400)
+    if not isinstance(payload, dict):
+        return JsonResponse({"error": "payload must be a JSON object"}, status=400)
+
+    sent_count = process_qbo_webhook_payload(payload)
+    return JsonResponse({"status": "ok", "notifications_sent": sent_count})
+
+
+def _valid_intuit_signature(body: bytes, signature: str, verifier_token: str) -> bool:
+    if not signature:
+        return False
+    digest = hmac.new(verifier_token.encode("utf-8"), body, hashlib.sha256).digest()
+    expected = base64.b64encode(digest).decode("ascii")
+    return hmac.compare_digest(expected, signature.strip())

--- a/apps/epos_qbo/webhooks.py
+++ b/apps/epos_qbo/webhooks.py
@@ -11,7 +11,7 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from .services.qbo_webhook_notifications import process_qbo_webhook_payload
+from .services.qbo_webhook_notifications import process_qbo_webhook_payload, record_rejected_webhook
 
 logger = logging.getLogger(__name__)
 
@@ -30,13 +30,16 @@ def quickbooks_webhook(request: HttpRequest) -> HttpResponse:
     signature = request.META.get(SIGNATURE_HEADER, "")
     if not _valid_intuit_signature(request.body, signature, verifier_token):
         logger.warning("QBO webhook rejected: invalid Intuit signature")
+        record_rejected_webhook(reason="Invalid Intuit signature.")
         return JsonResponse({"error": "invalid signature"}, status=401)
 
     try:
         payload = json.loads(request.body.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
+        record_rejected_webhook(reason="Invalid JSON payload.")
         return JsonResponse({"error": "invalid JSON"}, status=400)
     if not isinstance(payload, dict):
+        record_rejected_webhook(reason="Payload was not a JSON object.")
         return JsonResponse({"error": "payload must be a JSON object"}, status=400)
 
     sent_count = process_qbo_webhook_payload(payload)

--- a/apps/epos_qbo/webhooks.py
+++ b/apps/epos_qbo/webhooks.py
@@ -11,7 +11,7 @@ from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 
-from .services.qbo_webhook_notifications import process_qbo_webhook_payload, record_rejected_webhook
+from .services.qbo_webhook_notifications import process_qbo_webhook_body, record_rejected_webhook
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +38,11 @@ def quickbooks_webhook(request: HttpRequest) -> HttpResponse:
     except (UnicodeDecodeError, json.JSONDecodeError):
         record_rejected_webhook(reason="Invalid JSON payload.")
         return JsonResponse({"error": "invalid JSON"}, status=400)
-    if not isinstance(payload, dict):
-        record_rejected_webhook(reason="Payload was not a JSON object.")
-        return JsonResponse({"error": "payload must be a JSON object"}, status=400)
+    if not isinstance(payload, (dict, list)):
+        record_rejected_webhook(reason="Payload was not a supported JSON object or array.")
+        return JsonResponse({"error": "payload must be a supported JSON object or array"}, status=400)
 
-    sent_count = process_qbo_webhook_payload(payload)
+    sent_count = process_qbo_webhook_body(payload)
     return JsonResponse({"status": "ok", "notifications_sent": sent_count})
 
 

--- a/apps/epos_qbo/webhooks.py
+++ b/apps/epos_qbo/webhooks.py
@@ -25,21 +25,25 @@ def quickbooks_webhook(request: HttpRequest) -> HttpResponse:
     verifier_token = os.getenv(VERIFIER_TOKEN_ENV, "").strip()
     if not verifier_token:
         logger.error("QBO webhook rejected: %s is not configured", VERIFIER_TOKEN_ENV)
+        record_rejected_webhook(reason=f"{VERIFIER_TOKEN_ENV} is not configured.", payload=_request_fingerprint(request))
         return JsonResponse({"error": "webhook verifier not configured"}, status=503)
 
     signature = request.META.get(SIGNATURE_HEADER, "")
     if not _valid_intuit_signature(request.body, signature, verifier_token):
         logger.warning("QBO webhook rejected: invalid Intuit signature")
-        record_rejected_webhook(reason="Invalid Intuit signature.")
+        record_rejected_webhook(reason="Invalid Intuit signature.", payload=_request_fingerprint(request))
         return JsonResponse({"error": "invalid signature"}, status=401)
 
     try:
         payload = json.loads(request.body.decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
-        record_rejected_webhook(reason="Invalid JSON payload.")
+        record_rejected_webhook(reason="Invalid JSON payload.", payload=_request_fingerprint(request))
         return JsonResponse({"error": "invalid JSON"}, status=400)
     if not isinstance(payload, (dict, list)):
-        record_rejected_webhook(reason="Payload was not a supported JSON object or array.")
+        record_rejected_webhook(
+            reason="Payload was not a supported JSON object or array.",
+            payload={"request": _request_fingerprint(request), "payload_type": type(payload).__name__},
+        )
         return JsonResponse({"error": "payload must be a supported JSON object or array"}, status=400)
 
     sent_count = process_qbo_webhook_body(payload)
@@ -52,3 +56,18 @@ def _valid_intuit_signature(body: bytes, signature: str, verifier_token: str) ->
     digest = hmac.new(verifier_token.encode("utf-8"), body, hashlib.sha256).digest()
     expected = base64.b64encode(digest).decode("ascii")
     return hmac.compare_digest(expected, signature.strip())
+
+
+def _request_fingerprint(request: HttpRequest) -> dict[str, object]:
+    return {
+        "path": request.path,
+        "method": request.method,
+        "content_type": request.META.get("CONTENT_TYPE", ""),
+        "content_length": request.META.get("CONTENT_LENGTH", ""),
+        "user_agent": request.META.get("HTTP_USER_AGENT", ""),
+        "remote_addr": request.META.get("REMOTE_ADDR", ""),
+        "has_intuit_signature": bool(request.META.get(SIGNATURE_HEADER)),
+        "has_intuit_tid": bool(request.META.get("HTTP_INTUIT_T_ID")),
+        "intuit_created_time": request.META.get("HTTP_INTUIT_CREATED_TIME", ""),
+        "intuit_schema_version": request.META.get("HTTP_INTUIT_NOTIFICATION_SCHEMA_VERSION", ""),
+    }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,22 @@ services:
     restart: unless-stopped
     init: true
 
+  # Public ingress for inbound QuickBooks Online webhooks only.
+  # The portal itself stays tailnet-only (Caddy binds to TAILSCALE_BIND_IP); Intuit
+  # cannot reach a Tailscale CGNAT address, so the webhook endpoint is exposed via a
+  # Cloudflare Tunnel on a dedicated public hostname (qbo-webhooks.oiatsolutions.com).
+  # This connector runs in the compose network and reaches Django directly at
+  # http://web:8000. The public-hostname route and path restriction
+  # (Path = epos-qbo/webhooks/quickbooks) are configured on the tunnel in the
+  # Cloudflare Zero Trust dashboard; this container only needs the tunnel token.
+  cloudflared:
+    image: cloudflare/cloudflared:latest
+    container_name: ${COMPOSE_PROJECT_NAME:-oiat}-cloudflared
+    command: ["tunnel", "--no-autoupdate", "run", "--token", "${CLOUDFLARE_TUNNEL_TOKEN:?set CLOUDFLARE_TUNNEL_TOKEN in .env}"]
+    depends_on:
+      - web
+    restart: unless-stopped
+
 volumes:
   app-data:
   caddy_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,7 @@ services:
     command:
       - /bin/sh
       - -lc
-      - python manage.py migrate --noinput && exec gunicorn oiat_portal.wsgi:application --bind 0.0.0.0:8000 --workers ${GUNICORN_WORKERS:-2} --timeout ${GUNICORN_TIMEOUT:-180}
+      - python manage.py migrate --noinput && exec gunicorn oiat_portal.wsgi:application --bind 0.0.0.0:8000 --workers ${GUNICORN_WORKERS:-2} --timeout ${GUNICORN_TIMEOUT:-180} --access-logfile - --error-logfile -
     expose:
       - "8000"
 

--- a/docker/caddy/Caddyfile
+++ b/docker/caddy/Caddyfile
@@ -4,6 +4,11 @@
 }
 
 {$PORTAL_DOMAIN} {
+	log {
+		output stdout
+		format console
+	}
+
 	tls {
 		dns cloudflare {env.CF_API_TOKEN}
 		resolvers 1.1.1.1 1.0.0.1


### PR DESCRIPTION
## Summary
Adds the inbound QuickBooks Online webhook pipeline to the OIAT portal, plus the public ingress Intuit needs to reach it (the portal is otherwise tailnet-only).

### Webhook receiver
- CSRF-exempt `POST /epos-qbo/webhooks/quickbooks/` (and slashless variant); verifies the Intuit `intuit-signature` HMAC using `QBO_WEBHOOK_VERIFIER_TOKEN`.
- Persists every delivery to the `QboWebhookEvent` model (received / sent / skipped / failed / rejected); rejects store a redacted request fingerprint, not the body.
- Supports both legacy `eventNotifications` and CloudEvents payload shapes; special-cases the Intuit test realm `310687`.
- Forwards Slack notifications per company (`QBO_WEBHOOK_SLACK_URL_COMPANY_A/B`, `QBO_WEBHOOK_SLACK_URL_TEST`, fallback `QBO_WEBHOOK_SLACK_URL`); enriches `Item` events via a live QBO lookup.

### Public ingress (Cloudflare Tunnel)
- Caddy binds to the host Tailscale IP, so Intuit cannot reach the portal directly. Adds a `cloudflared` service that exposes **only** the webhook path on a dedicated public hostname, routed to `web:8000` (everything else → 404).
- New env var `CLOUDFLARE_TUNNEL_TOKEN`; the webhook hostname is added to `DJANGO_ALLOWED_HOSTS`.
- Documented in the README (Deployment → Webhook ingress), using generic placeholders only.

## Verification
- Deployed to prod: connector registered with Cloudflare, public `POST` → `401 invalid signature` with a persisted `rejected` row, and real QBO events now flow to Slack for configured companies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
