### PR TITLE
Show public webhook URL on portal Settings page

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,11 @@ CF_API_TOKEN=your_cloudflare_dns_api_token
 # DJANGO_ALLOWED_HOSTS above, since cloudflared forwards that Host header to Django.
 CLOUDFLARE_TUNNEL_TOKEN=your_cloudflare_tunnel_token
 
+# Public webhook URL shown on the portal Settings page and registered in Intuit.
+# Set this to the tunnel hostname (bare host or full URL) when the public webhook
+# endpoint differs from the tailnet-only portal domain. Falls back to PORTAL_DOMAIN.
+QBO_WEBHOOK_PUBLIC_URL=qbo-webhooks.your-domain.com
+
 # This section is for getting token info from the windows computer (optional)
 # Only needed if you're using a token broker setup
 QBO_TOKEN_BROKER_URL=http://127.0.0.1:8765/token

--- a/apps/epos_qbo/views.py
+++ b/apps/epos_qbo/views.py
@@ -1756,10 +1756,19 @@ def _scheduler_env_for_display():
 
 def _qbo_webhook_status_context():
     endpoint = "/epos-qbo/webhooks/quickbooks/"
-    base = str(getattr(settings, "OIAT_PORTAL_BASE_URL", "") or os.environ.get("PORTAL_DOMAIN", "")).strip()
-    if base and not base.startswith(("http://", "https://")):
-        base = f"https://{base}"
-    endpoint_url = f"{base.rstrip('/')}{endpoint}" if base else endpoint
+    # Intuit delivers to a public hostname (e.g. a Cloudflare Tunnel), which is not the
+    # same as the tailnet-only portal domain. Prefer an explicit public webhook URL/host
+    # when configured; otherwise fall back to the portal domain (older deployments).
+    public = os.environ.get("QBO_WEBHOOK_PUBLIC_URL", "").strip()
+    if public:
+        if not public.startswith(("http://", "https://")):
+            public = f"https://{public}"
+        endpoint_url = public if "/epos-qbo/webhooks/quickbooks" in public else f"{public.rstrip('/')}{endpoint}"
+    else:
+        base = str(getattr(settings, "OIAT_PORTAL_BASE_URL", "") or os.environ.get("PORTAL_DOMAIN", "")).strip()
+        if base and not base.startswith(("http://", "https://")):
+            base = f"https://{base}"
+        endpoint_url = f"{base.rstrip('/')}{endpoint}" if base else endpoint
     active_companies = CompanyConfigRecord.objects.filter(is_active=True).order_by("company_key")
     slack_destinations: list[dict[str, object]] = []
     for company in active_companies:


### PR DESCRIPTION
## Summary
The portal Settings page ("QuickBooks event alerts") built the webhook **Endpoint URL** from `PORTAL_DOMAIN`, which is the tailnet-only portal host. Since inbound webhooks now arrive via a public Cloudflare Tunnel hostname, the displayed URL was misleading (it showed the old `portal.…` URL, not the address Intuit actually delivers to).

## Change
- `_qbo_webhook_status_context()` now prefers a new `QBO_WEBHOOK_PUBLIC_URL` env var (bare host or full URL) when building the displayed endpoint, falling back to the previous `PORTAL_DOMAIN`-based behavior for older deployments.
- Documented `QBO_WEBHOOK_PUBLIC_URL` in `.env.example`.

Display-only change; the webhook route and handler are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
